### PR TITLE
Issue #34: Add React.FC type annotations to all components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import type { FC } from 'react';
 import { createClient } from '@supabase/supabase-js';
 
 import GameSetup from './components/GameSetup';
@@ -25,7 +26,7 @@ const supabase = createClient(supabaseUrl, supabaseKey);
 type GameState = 'setup' | 'scoring' | 'statistics' | 'history' | 'profile';
 
 // Main App Component - now just wraps the content with AuthProvider
-function App() {
+const App: FC = () => {
   return (
     <AuthProvider supabase={supabase}>
       <GamePersistProvider>
@@ -33,10 +34,10 @@ function App() {
       </GamePersistProvider>
     </AuthProvider>
   );
-}
+};
 
 // The actual app content, using the auth context
-function AppContent() {
+const AppContent: FC = () => {
   const { user, loading, signOut } = useAuth();
   const { getGameState, hasActiveGame, clearGameState } = useGamePersist();
 

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,9 @@
-/// <reference types="react-scripts" />
+/// <reference types="vite/client" />
+
+// Optional: augment env types if you want stricter typing for your VITE_ vars
+// interface ImportMetaEnv {
+//   readonly VITE_SUPABASE_KEY: string
+// }
+// interface ImportMeta {
+//   readonly env: ImportMetaEnv
+// }


### PR DESCRIPTION
Implements React.FC annotations for missing components (App, AppContent) and fixes Vite env typings. All tests pass and build succeeds. Closes #34.