### PR TITLE
✨ Add support for 1-point foul on break (Issue #63)

### DIFF
--- a/src/components/GameScoring/components/BreakFoulPenaltyModal.tsx
+++ b/src/components/GameScoring/components/BreakFoulPenaltyModal.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface BreakFoulPenaltyModalProps {
+  show: boolean;
+  onClose: () => void;
+  onSelectPenalty: (penalty: 1 | 2) => void;
+  playerName: string;
+}
+
+export const BreakFoulPenaltyModal: React.FC<BreakFoulPenaltyModalProps> = ({
+  show,
+  onClose,
+  onSelectPenalty,
+  playerName,
+}) => {
+  if (!show) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full p-6">
+        <div className="text-center mb-6">
+          <h3 className="text-xl font-bold text-gray-900 dark:text-white">
+            Break Foul Penalty
+          </h3>
+          <p className="text-gray-600 dark:text-gray-300 mt-2">
+            {playerName} fouled on the break.
+          </p>
+          <p className="text-gray-600 dark:text-gray-300 mt-2 font-medium">
+            What type of foul occurred?
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <button
+            onClick={() => onSelectPenalty(1)}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-3 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            <div className="font-bold text-lg mb-1">1-Point Foul</div>
+            <div className="text-sm opacity-90">
+              Break requirement met, but scratched
+            </div>
+          </button>
+          <button
+            onClick={() => onSelectPenalty(2)}
+            className="w-full bg-red-600 hover:bg-red-700 text-white py-3 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+          >
+            <div className="font-bold text-lg mb-1">2-Point Foul</div>
+            <div className="text-sm opacity-90">
+              Break requirement NOT met
+            </div>
+          </button>
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-4 text-left space-y-2">
+            <p className="font-semibold">Break requirement:</p>
+            <ul className="list-disc list-inside ml-2 space-y-1">
+              <li>Pocket a ball, OR</li>
+              <li>Cue ball + 2 object balls hit a rail</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
+++ b/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
@@ -144,7 +144,7 @@ describe('useGameActions', () => {
     expect(players[0].consecutiveFouls).toBe(0); // reset fouls
   });
 
-  test('handleAddFoul applies break foul penalty (-2 points)', () => {
+  test('handleAddFoul applies default break foul penalty (-2 points)', () => {
     const { result, players } = setup();
 
     act(() => {
@@ -152,6 +152,32 @@ describe('useGameActions', () => {
     });
 
     // Break foul logic: adds balls pocketed (1) then subtracts break foul penalty (-2) = -1 total
+    expect(players[0].score).toBe(-1); // 1 ball pocketed - 2 break foul penalty = -1
+    expect(players[0].fouls).toBe(1);
+    expect(players[0].consecutiveFouls).toBe(1);
+  });
+
+  test('handleAddFoul applies 1-point break foul penalty when specified', () => {
+    const { result, players } = setup();
+
+    act(() => {
+      result.current.handleAddFoul(14, 1);
+    });
+
+    // Break foul with 1-point penalty: adds balls pocketed (1) then subtracts 1-point penalty = 0 total
+    expect(players[0].score).toBe(0); // 1 ball pocketed - 1 break foul penalty = 0
+    expect(players[0].fouls).toBe(1);
+    expect(players[0].consecutiveFouls).toBe(1);
+  });
+
+  test('handleAddFoul applies 2-point break foul penalty when specified', () => {
+    const { result, players } = setup();
+
+    act(() => {
+      result.current.handleAddFoul(14, 2);
+    });
+
+    // Break foul with 2-point penalty: adds balls pocketed (1) then subtracts 2-point penalty = -1 total
     expect(players[0].score).toBe(-1); // 1 ball pocketed - 2 break foul penalty = -1
     expect(players[0].fouls).toBe(1);
     expect(players[0].consecutiveFouls).toBe(1);


### PR DESCRIPTION
## Summary

Implements the ability to assess either a **1-point or 2-point foul** on the break shot according to official 14.1 straight pool rules.

## Changes

### 🆕 New Component
- **BreakFoulPenaltyModal**: Modal that appears when a foul occurs on break
  - Allows selection between 1-point and 2-point foul
  - Displays clear explanations of each foul type
  - Shows break requirement reminder

### 📝 Modified Files

**useGameActions.ts** (`src/components/GameScoring/hooks/useGameActions.ts:104`)
- Added `foulPenalty` parameter to `handleAddFoul()`
- Updated penalty logic to accept 1 or 2 points
- Maintains backward compatibility (defaults to -2 for break fouls)

**GameScoring/index.tsx**
- Added state management for break foul penalty modal
- Modified foul button flow to show penalty selection on break shots
- Passes selected penalty to `handleAddFoul()`

**useGameActions.test.ts**
- Added tests for 1-point break foul penalty
- Added tests for 2-point break foul penalty
- Verified default behavior remains unchanged

## 📚 Rules Reference

**1-Point Foul on Break:**
- Break requirement met (ball pocketed OR cue ball + 2 object balls hit rail)
- Player scratched (cue ball in pocket or off table)

**2-Point Foul on Break:**
- Break requirement NOT met
- Applies whether player scratched or not

## ✅ Test Plan

- [x] All existing tests pass
- [x] New tests added for 1-point and 2-point break fouls
- [x] Build succeeds with no TypeScript errors
- [x] Manual testing: Click "Foul" on break shows penalty selection modal
- [x] Manual testing: Selecting 1-pt foul applies -1 penalty
- [x] Manual testing: Selecting 2-pt foul applies -2 penalty

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)