### PR TITLE
Tighten lint rules and refresh App tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ export default tseslint.config(
           fixStyle: 'inline-type-imports',
         },
       ],
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -124,5 +124,16 @@ export default tseslint.config(
         },
       ],
     },
-  }
+  },
+  {
+    files: [
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      '**/__tests__/**/*.{ts,tsx}',
+      'src/testing/**/*.{ts,tsx}',
+    ],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 );

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -60,12 +60,10 @@ describe('App Component', () => {
     localStorage.clear();
   });
 
-  // TODO: Fix test - UI content has changed
   test('renders header with app title', () => {
     render(<App />);
 
-    // Check for RunCount title (tagline now only appears during loading)
-    expect(screen.getByText('RunCount')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /RunCount/i })).toBeInTheDocument();
   });
 
   test('shows GameSetup component by default', async () => {
@@ -76,39 +74,33 @@ describe('App Component', () => {
     });
   });
 
-  // TODO: Fix test - button text has changed
   test('opens Authentication modal when clicking user icon (unauthenticated)', async () => {
     render(<App />);
 
-    // Click the user icon button in the header (last button in header controls when unauthenticated)
-    const header = screen.getByRole('banner');
-    const buttons = header.querySelectorAll('button');
-    const userIconButton = buttons[buttons.length - 1] as HTMLButtonElement;
-    fireEvent.click(userIconButton);
+    fireEvent.click(screen.getByRole('button', { name: /open authentication modal/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Authentication')).toBeInTheDocument();
     });
   });
 
-  // TODO: Fix test - footer content has changed
   test('shows navigation tab for New Game when not scoring', async () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText('New Game')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /New Game/i })).toBeInTheDocument();
     });
   });
 
-  // TODO: Fix test - navigation content has changed
   test('displays correct navigation labels when not authenticated', async () => {
     render(<App />);
 
     await waitFor(() => {
-      // Unauthenticated users only see New Game (History/Profile appear after login)
-      expect(screen.getByText('New Game')).toBeInTheDocument();
-      expect(screen.queryByText('History')).not.toBeInTheDocument();
-      expect(screen.queryByText('My Profile')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /New Game/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /History/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /My Profile/i }),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/GameStatistics.tsx
+++ b/src/components/GameStatistics.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect, useMemo } from 'react';
 
-import { type GameStatisticsProps, type GameData, type Player } from '../types/game';
+import {
+  type GameStatisticsProps,
+  type GameData,
+  type GameAction,
+  type Player,
+} from '../types/game';
 
 import { InningsModal } from './GameStatistics/components/InningsModal';
 import { StatDescriptionsModal } from './GameStatistics/components/StatDescriptionsModal';
@@ -112,7 +117,7 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
 
   // Memoize expensive statistics calculations
   const calculateStats = useMemo(
-    () => (players: Player[], actions: any[]) => {
+    () => (players: Player[], actions: GameAction[]) => {
       // Create a map to track results
       const playerStats: Record<
         number,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -117,6 +117,7 @@ export const Header: FC<HeaderProps> = ({
                 <button
                   className="bg-blue-700 hover:bg-blue-600 dark:bg-blue-800 dark:hover:bg-blue-700 p-2 rounded-full text-white"
                   onClick={onProfileClick}
+                  aria-label="Open profile menu"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -139,6 +140,7 @@ export const Header: FC<HeaderProps> = ({
                 <button
                   className="bg-gray-400 dark:bg-gray-600 hover:bg-gray-500 dark:hover:bg-gray-500 p-2 rounded-full text-gray-300 dark:text-gray-400 hover:text-gray-200 transition-colors"
                   onClick={onAuthClick}
+                  aria-label="Open authentication modal"
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -7,6 +7,13 @@ interface LoginProps {
   onSuccess?: () => void;
 }
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+};
+
 const Login: React.FC<LoginProps> = ({ supabase, onSuccess }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -30,8 +37,8 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess }) => {
       if (onSuccess) {
         onSuccess();
       }
-    } catch (error: any) {
-      setError(error.message || 'An error occurred during login');
+    } catch (error) {
+      setError(getErrorMessage(error, 'An error occurred during login'));
     } finally {
       setLoading(false);
     }
@@ -50,8 +57,8 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess }) => {
       });
 
       if (error) throw error;
-    } catch (error: any) {
-      setError(error.message || `An error occurred during ${provider} login`);
+    } catch (error) {
+      setError(getErrorMessage(error, `An error occurred during ${provider} login`));
     } finally {
       setLoading(false);
     }

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -7,6 +7,13 @@ interface ResetPasswordProps {
   onSuccess?: () => void;
 }
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+};
+
 const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) => {
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
@@ -40,8 +47,8 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
           onSuccess();
         }, 2000);
       }
-    } catch (error: any) {
-      setError(error.message || 'An error occurred');
+    } catch (error) {
+      setError(getErrorMessage(error, 'An error occurred'));
     } finally {
       setLoading(false);
     }
@@ -75,8 +82,8 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
           onSuccess();
         }, 2000);
       }
-    } catch (error: any) {
-      setError(error.message || 'An error occurred');
+    } catch (error) {
+      setError(getErrorMessage(error, 'An error occurred'));
     } finally {
       setLoading(false);
     }

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -7,6 +7,13 @@ interface SignUpProps {
   onSuccess?: () => void;
 }
 
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+};
+
 const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -43,8 +50,8 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
       if (onSuccess) {
         onSuccess();
       }
-    } catch (error: any) {
-      setError(error.message || 'An error occurred during sign up');
+    } catch (error) {
+      setError(getErrorMessage(error, 'An error occurred during sign up'));
     } finally {
       setLoading(false);
     }
@@ -63,8 +70,8 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
       });
 
       if (error) throw error;
-    } catch (error: any) {
-      setError(error.message || `An error occurred during ${provider} sign up`);
+    } catch (error) {
+      setError(getErrorMessage(error, `An error occurred during ${provider} sign up`));
     } finally {
       setLoading(false);
     }

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -8,6 +8,13 @@ interface UserProfileProps {
   onSignOut: () => Promise<void>;
 }
 
+const getErrorMessage = (error: unknown, fallback = 'An error occurred') => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+};
+
 const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,8 +43,8 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
       setNewEmail('');
       setShowSuccessAnimation(true);
       setTimeout(() => setShowSuccessAnimation(false), 2000);
-    } catch (error: any) {
-      setError(error.message || 'An error occurred');
+    } catch (error) {
+      setError(getErrorMessage(error));
     } finally {
       setLoading(false);
     }
@@ -67,8 +74,8 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
       setConfirmPassword('');
       setShowSuccessAnimation(true);
       setTimeout(() => setShowSuccessAnimation(false), 2000);
-    } catch (error: any) {
-      setError(error.message || 'An error occurred');
+    } catch (error) {
+      setError(getErrorMessage(error));
     } finally {
       setLoading(false);
     }

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
+import React, { type ErrorInfo } from 'react';
 
 import { useError } from '../../context/ErrorContext';
 
+type ErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
 export class ErrorBoundary extends React.Component<
-  {
-    children: React.ReactNode;
-  },
-  { hasError: boolean }
+  ErrorBoundaryProps,
+  ErrorBoundaryState
 > {
   static contextType = React.createContext(null);
   declare context: React.ContextType<typeof ErrorBoundary.contextType>;
 
-  constructor(props: any) {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
   }
@@ -20,7 +26,7 @@ export class ErrorBoundary extends React.Component<
     return { hasError: true };
   }
 
-  componentDidCatch(error: any, info: any) {
+  componentDidCatch(error: Error, info: ErrorInfo) {
     // Fallback: try using window.dispatchEvent to signal error if context is not available
     try {
       const event = new CustomEvent('appError', {

--- a/src/components/shared/GameStatusPanel.tsx
+++ b/src/components/shared/GameStatusPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { type Player } from '../../types/game';
+import { type Player, type GameAction } from '../../types/game';
 
 import { type StatCalculator } from './types';
 
@@ -14,7 +14,7 @@ interface GameStatusPanelProps {
   onCopyResults: () => void;
   onViewInnings?: () => void;
   copySuccess: boolean;
-  actions: any[];
+  actions: GameAction[];
 }
 
 export const GameStatusPanel: React.FC<GameStatusPanelProps> = ({

--- a/src/hooks/useFullscreen.ts
+++ b/src/hooks/useFullscreen.ts
@@ -2,6 +2,21 @@ import { useState, useEffect, useCallback } from 'react';
 
 import { useError } from '../context/ErrorContext';
 
+type VendorDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  mozFullScreenElement?: Element | null;
+  msFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+};
+
+type VendorDocumentElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullScreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
+
 /**
  * Custom hook for managing fullscreen state and functionality
  * Handles vendor prefixes for cross-browser compatibility
@@ -12,12 +27,13 @@ export const useFullscreen = () => {
 
   // Listen for fullscreen changes
   useEffect(() => {
+    const vendorDocument = document as VendorDocument;
     const handleFullscreenChange = () => {
       const isFullscreen = !!(
-        document.fullscreenElement ||
-        (document as any).webkitFullscreenElement ||
-        (document as any).mozFullScreenElement ||
-        (document as any).msFullscreenElement
+        vendorDocument.fullscreenElement ||
+        vendorDocument.webkitFullscreenElement ||
+        vendorDocument.mozFullScreenElement ||
+        vendorDocument.msFullscreenElement
       );
       setIsFullScreen(isFullscreen);
     };
@@ -38,27 +54,27 @@ export const useFullscreen = () => {
 
   const toggleFullscreen = useCallback(async () => {
     try {
-      const doc = document as any;
-      const docEl = document.documentElement as any;
+      const vendorDocument = document as VendorDocument;
+      const vendorDocumentElement = document.documentElement as VendorDocumentElement;
 
       // Check if already in fullscreen (with vendor prefixes)
       const isCurrentlyFullscreen = !!(
         document.fullscreenElement ||
-        doc.webkitFullscreenElement ||
-        doc.mozFullScreenElement ||
-        doc.msFullscreenElement
+        vendorDocument.webkitFullscreenElement ||
+        vendorDocument.mozFullScreenElement ||
+        vendorDocument.msFullscreenElement
       );
 
       if (!isCurrentlyFullscreen) {
         // Request fullscreen with vendor prefix support
-        if (docEl.requestFullscreen) {
-          await docEl.requestFullscreen();
-        } else if (docEl.webkitRequestFullscreen) {
-          await docEl.webkitRequestFullscreen();
-        } else if (docEl.mozRequestFullScreen) {
-          await docEl.mozRequestFullScreen();
-        } else if (docEl.msRequestFullscreen) {
-          await docEl.msRequestFullscreen();
+        if (vendorDocumentElement.requestFullscreen) {
+          await vendorDocumentElement.requestFullscreen();
+        } else if (vendorDocumentElement.webkitRequestFullscreen) {
+          await vendorDocumentElement.webkitRequestFullscreen();
+        } else if (vendorDocumentElement.mozRequestFullScreen) {
+          await vendorDocumentElement.mozRequestFullScreen();
+        } else if (vendorDocumentElement.msRequestFullscreen) {
+          await vendorDocumentElement.msRequestFullscreen();
         } else {
           throw new Error('Fullscreen not supported');
         }
@@ -66,12 +82,12 @@ export const useFullscreen = () => {
         // Exit fullscreen with vendor prefix support
         if (document.exitFullscreen) {
           await document.exitFullscreen();
-        } else if (doc.webkitExitFullscreen) {
-          await doc.webkitExitFullscreen();
-        } else if (doc.mozCancelFullScreen) {
-          await doc.mozCancelFullScreen();
-        } else if (doc.msExitFullscreen) {
-          await doc.msExitFullscreen();
+        } else if (vendorDocument.webkitExitFullscreen) {
+          await vendorDocument.webkitExitFullscreen();
+        } else if (vendorDocument.mozCancelFullScreen) {
+          await vendorDocument.mozCancelFullScreen();
+        } else if (vendorDocument.msExitFullscreen) {
+          await vendorDocument.msExitFullscreen();
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- add accessible labels and modernize App header/navigation tests to match current UI
- re-enable @typescript-eslint/no-explicit-any (with test overrides) and strongly type runtime hooks/modules
- improve auth/profile error handling and fullscreen helpers so the stricter lint rules pass cleanly

## Testing
- npm run lint
- npm run test