### PR TITLE
Compact game setup screen with tap-to-select breaker

### DIFF
--- a/src/__tests__/error-recovery.integration.test.tsx
+++ b/src/__tests__/error-recovery.integration.test.tsx
@@ -218,17 +218,17 @@ describe('Error Recovery Integration Tests', () => {
     await userEvent.clear(player2Input);
     await userEvent.type(player2Input, 'Bob');
 
-    // Rapid button clicks on breaking player selection
-    const player1BreakBtn = screen.getByRole('button', {
-      name: /Select .*Alice.* breaking player/i,
+    // Rapid clicks on breaking player selection cards
+    const player1Card = screen.getByRole('button', {
+      name: /Player 1.*tap to select/i,
     });
-    const player2BreakBtn = screen.getByRole('button', {
-      name: /Select .*Bob.* breaking player/i,
+    const player2Card = screen.getByRole('button', {
+      name: /Player 2.*tap to select/i,
     });
 
-    await userEvent.click(player2BreakBtn);
-    await userEvent.click(player1BreakBtn);
-    await userEvent.click(player2BreakBtn);
+    await userEvent.click(player2Card);
+    await userEvent.click(player1Card);
+    await userEvent.click(player2Card);
 
     // Start game
     await userEvent.click(screen.getByRole('button', { name: /Start Game/i }));

--- a/src/components/GameSetup.test.tsx
+++ b/src/components/GameSetup.test.tsx
@@ -41,17 +41,15 @@ describe('GameSetup Component', () => {
 
     expect(screen.getByRole('button', { name: /Start Game/i })).toBeInTheDocument();
 
-    // Check default values for numeric inputs using their IDs
+    // Check default values for numeric inputs
     expect(screen.getByDisplayValue(75)).toBeInTheDocument(); // Player 1 target score
     expect(screen.getByDisplayValue(60)).toBeInTheDocument(); // Player 2 target score
 
     // Check breaking player selection (Player 1 should be default)
-    const breakingButtons = screen.getAllByRole('button', {
-      pressed: true,
-      name: /Select .* breaking player/i,
+    const player1Card = screen.getByRole('button', {
+      name: /Player 1.*breaking/i,
     });
-    expect(breakingButtons).toHaveLength(1);
-    expect(breakingButtons[0]).toHaveAttribute('aria-pressed', 'true');
+    expect(player1Card).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('displays error when submitting with empty player names', async () => {
@@ -105,7 +103,7 @@ describe('GameSetup Component', () => {
     await userEvent.type(screen.getByLabelText('Player 1 name'), 'Player One');
     await userEvent.type(screen.getByLabelText('Player 2 name'), 'Player Two');
 
-    // Set invalid target score - use ID selector instead of label
+    // Set invalid target score
     const player1TargetScore = screen.getByDisplayValue(75);
     await userEvent.clear(player1TargetScore);
     await userEvent.type(player1TargetScore, '0');
@@ -166,11 +164,11 @@ describe('GameSetup Component', () => {
     await userEvent.type(screen.getByLabelText('Player 1 name'), 'Player One');
     await userEvent.type(screen.getByLabelText('Player 2 name'), 'Player Two');
 
-    // Select Player 2 as the breaking player - find by player name text in button
-    const player2Button = screen.getByRole('button', {
-      name: /Select .*Player Two.* breaking player/i,
+    // Select Player 2 as the breaking player by clicking the player card
+    const player2Card = screen.getByRole('button', {
+      name: /Player 2 - tap to select/i,
     });
-    fireEvent.click(player2Button);
+    fireEvent.click(player2Card);
 
     // Submit form
     fireEvent.click(screen.getByRole('button', { name: /Start Game/i }));
@@ -207,17 +205,17 @@ describe('GameSetup Component', () => {
     expect(screen.getByDisplayValue(125)).toBeInTheDocument(); // John's target score
     expect(screen.getByDisplayValue(100)).toBeInTheDocument(); // Mike's target score
 
-    // Check that Mike (Player 2) is selected as breaking
-    const player2BreakBtn = screen.getByRole('button', {
-      name: /Select .*Mike.* breaking player/i,
+    // Check that Player 2 is selected as breaking (aria-pressed=true)
+    const player2Card = screen.getByRole('button', {
+      name: /Player 2.*breaking/i,
     });
-    expect(player2BreakBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(player2Card).toHaveAttribute('aria-pressed', 'true');
 
-    // Check that Player 1 is no longer selected
-    const player1BreakBtn = screen.getByRole('button', {
-      name: /Select .*John.* breaking player/i,
+    // Check that Player 1 is not selected
+    const player1Card = screen.getByRole('button', {
+      name: /Player 1 - tap to select/i,
     });
-    expect(player1BreakBtn).toHaveAttribute('aria-pressed', 'false');
+    expect(player1Card).toHaveAttribute('aria-pressed', 'false');
   });
 
   test('target score inputs work correctly', async () => {
@@ -227,27 +225,27 @@ describe('GameSetup Component', () => {
       </GamePersistProvider>,
     );
 
-    // Find the score inputs by their placeholders
-    const player1ScoreInput = screen.getByDisplayValue(75);
-    const player2ScoreInput = screen.getByDisplayValue(60);
+    // Find the score inputs by their values
+    const player1ScoreInput = screen.getByDisplayValue('75');
+    const player2ScoreInput = screen.getByDisplayValue('60');
 
     // Initial values should be 75 and 60
-    expect(player1ScoreInput).toHaveValue(75);
-    expect(player2ScoreInput).toHaveValue(60);
+    expect(player1ScoreInput).toHaveValue('75');
+    expect(player2ScoreInput).toHaveValue('60');
 
     // Test direct input for player 1
     await userEvent.clear(player1ScoreInput);
     await userEvent.type(player1ScoreInput, '83');
-    expect(player1ScoreInput).toHaveValue(83);
+    expect(player1ScoreInput).toHaveValue('83');
 
     // Test direct input for player 2
     await userEvent.clear(player2ScoreInput);
     await userEvent.type(player2ScoreInput, '47');
-    expect(player2ScoreInput).toHaveValue(47);
+    expect(player2ScoreInput).toHaveValue('47');
 
     // Test minimum value validation (should accept any positive number)
     await userEvent.clear(player1ScoreInput);
     await userEvent.type(player1ScoreInput, '1');
-    expect(player1ScoreInput).toHaveValue(1);
+    expect(player1ScoreInput).toHaveValue('1');
   });
 });

--- a/src/components/GameSetup.tsx
+++ b/src/components/GameSetup.tsx
@@ -20,10 +20,9 @@ const GameSetup: React.FC<GameSetupProps> = ({
   const [player2, setPlayer2] = useState('');
   const [player1TargetScore, setPlayer1TargetScore] = useState(DEFAULT_PLAYER1_TARGET);
   const [player2TargetScore, setPlayer2TargetScore] = useState(DEFAULT_PLAYER2_TARGET);
-  const [breakingPlayerId, setBreakingPlayerId] = useState<number>(0); // Default to player 1
+  const [breakingPlayerId, setBreakingPlayerId] = useState<number>(0);
   const [error, setError] = useState('');
 
-  // Set up form using last game settings if available
   useEffect(() => {
     if (lastPlayers && lastPlayers.length >= 2) {
       setPlayer1(lastPlayers[0]);
@@ -31,7 +30,6 @@ const GameSetup: React.FC<GameSetupProps> = ({
     }
 
     if (lastPlayerTargetScores) {
-      // If we have last player target scores and player names
       if (lastPlayers && lastPlayers.length >= 2) {
         if (lastPlayerTargetScores[lastPlayers[0]]) {
           setPlayer1TargetScore(lastPlayerTargetScores[lastPlayers[0]]);
@@ -42,7 +40,6 @@ const GameSetup: React.FC<GameSetupProps> = ({
       }
     }
 
-    // Set the breaking player if available from last game
     if (lastBreakingPlayerId !== undefined) {
       setBreakingPlayerId(lastBreakingPlayerId);
     }
@@ -71,10 +68,7 @@ const GameSetup: React.FC<GameSetupProps> = ({
       [player2]: player2TargetScore,
     };
 
-    // Clear any existing game state when starting a new game
     clearGameState();
-
-    // Start new game with breaking player ID
     startGame([player1, player2], playerTargetScores, breakingPlayerId);
   };
 
@@ -82,23 +76,23 @@ const GameSetup: React.FC<GameSetupProps> = ({
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 p-4">
       <div className="max-w-md mx-auto pt-8">
         {/* Header */}
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
             New Game
           </h1>
-          <p className="text-gray-500 dark:text-gray-400">
-            Set up your straight pool match
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Tap a player to select who breaks
           </p>
         </div>
 
         {/* Error Message */}
         {error && (
-          <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-2xl mb-6 shadow-sm">
-            <span className="block">{error}</span>
+          <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-xl mb-4 text-sm">
+            {error}
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-6">
+        <form onSubmit={handleSubmit} className="space-y-3">
           <PlayerCard
             playerNumber={1}
             playerName={player1}
@@ -106,6 +100,8 @@ const GameSetup: React.FC<GameSetupProps> = ({
             onPlayerNameChange={setPlayer1}
             onTargetScoreChange={setPlayer1TargetScore}
             colorScheme="blue"
+            isBreaking={breakingPlayerId === 0}
+            onSelectBreaking={() => setBreakingPlayerId(0)}
           />
 
           <PlayerCard
@@ -115,97 +111,14 @@ const GameSetup: React.FC<GameSetupProps> = ({
             onPlayerNameChange={setPlayer2}
             onTargetScoreChange={setPlayer2TargetScore}
             colorScheme="green"
+            isBreaking={breakingPlayerId === 1}
+            onSelectBreaking={() => setBreakingPlayerId(1)}
           />
-
-          {/* Breaking Player Card */}
-          <div className="bg-white dark:bg-gray-800 rounded-3xl p-6 shadow-lg border border-gray-100 dark:border-gray-700">
-            <div className="flex items-center mb-6">
-              <div className="w-10 h-10 bg-orange-100 dark:bg-orange-900 rounded-full flex items-center justify-center mr-3">
-                <span className="text-orange-600 dark:text-orange-400 text-xl">🎱</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                  Breaking Player
-                </h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Who takes the first shot?
-                </p>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-3">
-              <button
-                type="button"
-                onClick={() => setBreakingPlayerId(0)}
-                aria-pressed={breakingPlayerId === 0}
-                aria-label={`Select ${player1 || 'Player 1'} as breaking player`}
-                className={`p-4 rounded-2xl border-2 transition-all duration-200 ${
-                  breakingPlayerId === 0
-                    ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30'
-                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
-                }`}
-              >
-                <div className="text-center">
-                  <div
-                    className={`w-8 h-8 rounded-full mx-auto mb-2 flex items-center justify-center ${
-                      breakingPlayerId === 0
-                        ? 'bg-blue-500'
-                        : 'bg-gray-300 dark:bg-gray-600'
-                    }`}
-                  >
-                    <span className="text-white text-sm font-semibold">1</span>
-                  </div>
-                  <p
-                    className={`text-sm font-medium ${
-                      breakingPlayerId === 0
-                        ? 'text-blue-600 dark:text-blue-400'
-                        : 'text-gray-600 dark:text-gray-400'
-                    }`}
-                  >
-                    {player1 || 'Player 1'}
-                  </p>
-                </div>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => setBreakingPlayerId(1)}
-                aria-pressed={breakingPlayerId === 1}
-                aria-label={`Select ${player2 || 'Player 2'} as breaking player`}
-                className={`p-4 rounded-2xl border-2 transition-all duration-200 ${
-                  breakingPlayerId === 1
-                    ? 'border-green-500 bg-green-50 dark:bg-green-900/30'
-                    : 'border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500'
-                }`}
-              >
-                <div className="text-center">
-                  <div
-                    className={`w-8 h-8 rounded-full mx-auto mb-2 flex items-center justify-center ${
-                      breakingPlayerId === 1
-                        ? 'bg-green-500'
-                        : 'bg-gray-300 dark:bg-gray-600'
-                    }`}
-                  >
-                    <span className="text-white text-sm font-semibold">2</span>
-                  </div>
-                  <p
-                    className={`text-sm font-medium ${
-                      breakingPlayerId === 1
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-gray-600 dark:text-gray-400'
-                    }`}
-                  >
-                    {player2 || 'Player 2'}
-                  </p>
-                </div>
-              </button>
-            </div>
-          </div>
 
           {/* Start Game Button */}
           <button
             type="submit"
-            className="w-full bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white py-4 px-8 rounded-2xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-[1.02] transition-all duration-200"
+            className="w-full bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white py-4 px-8 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-[1.02] transition-all duration-200 mt-4"
           >
             Start Game
           </button>

--- a/src/components/PlayerCard.test.tsx
+++ b/src/components/PlayerCard.test.tsx
@@ -7,6 +7,7 @@ import PlayerCard from './PlayerCard';
 describe('PlayerCard Component', () => {
   const mockOnPlayerNameChange = vi.fn();
   const mockOnTargetScoreChange = vi.fn();
+  const mockOnSelectBreaking = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -24,7 +25,7 @@ describe('PlayerCard Component', () => {
       />,
     );
 
-    expect(screen.getByText('Player 1')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.getByLabelText('Player 1 name')).toBeInTheDocument();
   });
 
@@ -80,7 +81,7 @@ describe('PlayerCard Component', () => {
     expect(mockOnTargetScoreChange).toHaveBeenCalledWith(125);
   });
 
-  test('renders all quick-select score buttons', () => {
+  test('shows breaking indicator when isBreaking is true', () => {
     render(
       <PlayerCard
         playerNumber={1}
@@ -89,18 +90,15 @@ describe('PlayerCard Component', () => {
         onPlayerNameChange={mockOnPlayerNameChange}
         onTargetScoreChange={mockOnTargetScoreChange}
         colorScheme="blue"
+        isBreaking={true}
       />,
     );
 
-    const expectedScores = [50, 75, 100, 125, 150];
-    expectedScores.forEach((score) => {
-      expect(
-        screen.getByLabelText(`Set Player 1 target score to ${score} points`),
-      ).toBeInTheDocument();
-    });
+    expect(screen.getByText('Breaking')).toBeInTheDocument();
+    expect(screen.getByText('🎱')).toBeInTheDocument();
   });
 
-  test('quick-select button updates target score', () => {
+  test('does not show breaking indicator when isBreaking is false', () => {
     render(
       <PlayerCard
         playerNumber={1}
@@ -109,16 +107,14 @@ describe('PlayerCard Component', () => {
         onPlayerNameChange={mockOnPlayerNameChange}
         onTargetScoreChange={mockOnTargetScoreChange}
         colorScheme="blue"
+        isBreaking={false}
       />,
     );
 
-    const button100 = screen.getByLabelText('Set Player 1 target score to 100 points');
-    fireEvent.click(button100);
-
-    expect(mockOnTargetScoreChange).toHaveBeenCalledWith(100);
+    expect(screen.queryByText('Breaking')).not.toBeInTheDocument();
   });
 
-  test('quick-select buttons expose selection state via aria-pressed', () => {
+  test('calls onSelectBreaking when card is clicked', () => {
     render(
       <PlayerCard
         playerNumber={1}
@@ -127,20 +123,14 @@ describe('PlayerCard Component', () => {
         onPlayerNameChange={mockOnPlayerNameChange}
         onTargetScoreChange={mockOnTargetScoreChange}
         colorScheme="blue"
+        onSelectBreaking={mockOnSelectBreaking}
       />,
     );
 
-    const selectedButton = screen.getByLabelText(
-      'Set Player 1 target score to 75 points',
-    );
-    const unselectedButton = screen.getByLabelText(
-      'Set Player 1 target score to 50 points',
-    );
+    const card = screen.getByRole('button', { name: /Player 1/i });
+    fireEvent.click(card);
 
-    expect(selectedButton).toHaveAttribute('aria-pressed', 'true');
-    expect(selectedButton).toHaveAttribute('data-state', 'selected');
-    expect(unselectedButton).toHaveAttribute('aria-pressed', 'false');
-    expect(unselectedButton).toHaveAttribute('data-state', 'unselected');
+    expect(mockOnSelectBreaking).toHaveBeenCalled();
   });
 
   test('has required attribute on name input', () => {
@@ -175,7 +165,7 @@ describe('PlayerCard Component', () => {
     expect(scoreInput).toBeRequired();
   });
 
-  test('target score input has min and step attributes', () => {
+  test('target score input uses numeric keyboard on mobile', () => {
     render(
       <PlayerCard
         playerNumber={1}
@@ -188,7 +178,7 @@ describe('PlayerCard Component', () => {
     );
 
     const scoreInput = screen.getByLabelText('Player 1 target score');
-    expect(scoreInput).toHaveAttribute('min', '1');
-    expect(scoreInput).toHaveAttribute('step', '1');
+    expect(scoreInput).toHaveAttribute('inputMode', 'numeric');
+    expect(scoreInput).toHaveAttribute('pattern', '[0-9]*');
   });
 });

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { COMMON_TARGET_SCORES } from '../constants/gameSettings';
 import { PLAYER_COLOR_SCHEMES } from '../constants/theme';
 
 interface PlayerCardProps {
@@ -10,6 +9,8 @@ interface PlayerCardProps {
   onPlayerNameChange: (name: string) => void;
   onTargetScoreChange: (score: number) => void;
   colorScheme: 'blue' | 'green';
+  isBreaking?: boolean;
+  onSelectBreaking?: () => void;
 }
 
 const PlayerCard: React.FC<PlayerCardProps> = ({
@@ -19,85 +20,80 @@ const PlayerCard: React.FC<PlayerCardProps> = ({
   onPlayerNameChange,
   onTargetScoreChange,
   colorScheme,
+  isBreaking = false,
+  onSelectBreaking,
 }) => {
   const color = PLAYER_COLOR_SCHEMES[colorScheme];
 
+  const handleCardClick = (e: React.MouseEvent) => {
+    // Don't trigger if clicking on inputs
+    if ((e.target as HTMLElement).tagName === 'INPUT') {
+      return;
+    }
+    onSelectBreaking?.();
+  };
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-3xl p-6 shadow-lg border border-gray-100 dark:border-gray-700">
-      <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-          Player {playerNumber}
-        </h3>
+    <div
+      onClick={handleCardClick}
+      className={`bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-md border-2 transition-all duration-200 cursor-pointer ${
+        isBreaking
+          ? `${color.borderActive} ${color.bgLight}`
+          : 'border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600'
+      }`}
+      role="button"
+      aria-pressed={isBreaking}
+      aria-label={`Player ${playerNumber}${isBreaking ? ' (breaking)' : ''} - tap to select as breaking player`}
+    >
+      <div className="flex items-center gap-3">
+        {/* Player badge */}
         <div
-          className={`w-8 h-8 ${color.badge} rounded-full flex items-center justify-center`}
+          className={`w-8 h-8 ${isBreaking ? color.badge : 'bg-gray-200 dark:bg-gray-600'} rounded-full flex items-center justify-center flex-shrink-0`}
         >
-          <span className={`${color.badgeText} text-sm font-semibold`}>
+          <span
+            className={`text-sm font-semibold ${isBreaking ? color.badgeText : 'text-gray-500 dark:text-gray-400'}`}
+          >
             {playerNumber}
           </span>
         </div>
-      </div>
 
-      <div className="space-y-4">
-        <div>
+        {/* Name input */}
+        <input
+          type="text"
+          value={playerName}
+          onChange={(e) => onPlayerNameChange(e.target.value)}
+          className="flex-1 text-lg font-semibold bg-transparent border-none outline-none placeholder-gray-300 dark:placeholder-gray-600 text-gray-900 dark:text-white min-w-0"
+          placeholder={`Player ${playerNumber}`}
+          aria-label={`Player ${playerNumber} name`}
+          required
+        />
+
+        {/* Target score input */}
+        <div className="flex items-center gap-1 flex-shrink-0">
           <input
             type="text"
-            id={`player${playerNumber}`}
-            value={playerName}
-            onChange={(e) => onPlayerNameChange(e.target.value)}
-            className="w-full text-2xl font-bold bg-transparent border-none outline-none placeholder-gray-300 dark:placeholder-gray-600 text-gray-900 dark:text-white"
-            placeholder="Enter name"
-            aria-label={`Player ${playerNumber} name`}
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={targetScore}
+            onChange={(e) => {
+              const val = e.target.value.replace(/\D/g, '');
+              onTargetScoreChange(val ? Number(val) : 0);
+            }}
+            className="w-16 text-lg font-bold bg-gray-100 dark:bg-gray-700 rounded-lg px-2 py-1 text-center text-gray-900 dark:text-white"
+            aria-label={`Player ${playerNumber} target score`}
             required
           />
-        </div>
-
-        <div className="flex items-end justify-between">
-          <div className="flex-1">
-            <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
-              Target Score
-            </p>
-            <div className="flex items-baseline mb-3">
-              <input
-                type="number"
-                id={`player${playerNumber}TargetScore`}
-                value={targetScore}
-                onChange={(e) => onTargetScoreChange(Number(e.target.value))}
-                className="text-4xl font-bold bg-transparent border-none outline-none w-20 text-gray-900 dark:text-white [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                min="1"
-                step="1"
-                aria-label={`Player ${playerNumber} target score`}
-                required
-              />
-              <span className="text-xl text-gray-400 dark:text-gray-500 ml-1">pts</span>
-            </div>
-            <div className="flex gap-1.5">
-              {COMMON_TARGET_SCORES.map((score) => {
-                const isSelected = targetScore === score;
-                return (
-                  <button
-                    key={score}
-                    type="button"
-                    onClick={() => onTargetScoreChange(score)}
-                    aria-label={`Set Player ${playerNumber} target score to ${score} points`}
-                    aria-pressed={isSelected}
-                    data-state={isSelected ? 'selected' : 'unselected'}
-                    className={`px-2 py-1 text-xs rounded-lg transition-colors ${
-                      isSelected ? color.button : color.buttonInactive
-                    }`}
-                  >
-                    {score}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-          <div
-            className={`w-16 h-16 ${color.gradient} rounded-2xl flex items-center justify-center ml-4`}
-          >
-            <span className="text-white text-2xl">🎯</span>
-          </div>
+          <span className="text-sm text-gray-400 dark:text-gray-500">pts</span>
         </div>
       </div>
+
+      {/* Breaking indicator */}
+      {isBreaking && (
+        <div className={`mt-2 text-xs font-medium ${color.text} flex items-center gap-1`}>
+          <span>🎱</span>
+          <span>Breaking</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -8,6 +8,9 @@ export interface ColorScheme {
   gradient: string;
   button: string;
   buttonInactive: string;
+  borderActive: string;
+  bgLight: string;
+  text: string;
 }
 
 export const PLAYER_COLOR_SCHEMES: Record<'blue' | 'green', ColorScheme> = {
@@ -18,6 +21,9 @@ export const PLAYER_COLOR_SCHEMES: Record<'blue' | 'green', ColorScheme> = {
     button: 'bg-blue-500 text-white',
     buttonInactive:
       'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600',
+    borderActive: 'border-blue-500',
+    bgLight: 'bg-blue-50 dark:bg-blue-900/20',
+    text: 'text-blue-600 dark:text-blue-400',
   },
   green: {
     badge: 'bg-green-100 dark:bg-green-900',
@@ -26,5 +32,8 @@ export const PLAYER_COLOR_SCHEMES: Record<'blue' | 'green', ColorScheme> = {
     button: 'bg-green-500 text-white',
     buttonInactive:
       'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600',
+    borderActive: 'border-green-500',
+    bgLight: 'bg-green-50 dark:bg-green-900/20',
+    text: 'text-green-600 dark:text-green-400',
   },
 };


### PR DESCRIPTION
## Summary
- Simplified game setup screen to fit on one screen
- Tap a player row to select them as breaking player
- Removed preset score buttons (just direct input now)
- Numeric-only keyboard on mobile for score input

## Changes
- `PlayerCard` redesigned as compact single-row component
- Breaking player selection integrated into player cards
- Score input uses `inputMode="numeric"` for mobile keyboard
- Score input widened to fit 3 digits
- Removed `COMMON_TARGET_SCORES` quick-select buttons

## Test plan
- [x] All 124 tests pass
- [x] Tested in iOS simulator
- [x] Numeric keyboard shows on mobile
- [x] Tap-to-select breaker works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)