### PR TITLE
Add auth flow regression tests

### DIFF
--- a/src/components/__tests__/GameStatistics.test.tsx
+++ b/src/components/__tests__/GameStatistics.test.tsx
@@ -97,7 +97,7 @@ describe('GameStatistics Component', () => {
     localStorage.clear();
   });
 
-  test('renders loading state initially', () => {
+  test('renders loading state initially', async () => {
     render(
       <GameStatistics
         gameId="game-1"
@@ -111,6 +111,10 @@ describe('GameStatistics Component', () => {
     expect(
       screen.getByRole('status', { name: 'Loading game statistics...' }),
     ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/error/i)).toBeInTheDocument();
+    });
   });
 
   test('shows error when no game ID provided', async () => {

--- a/src/components/auth/Login.test.tsx
+++ b/src/components/auth/Login.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import Login from './Login';
+
+describe('Login', () => {
+  const signInWithPassword = vi.fn();
+  const signInWithOAuth = vi.fn();
+  const onSuccess = vi.fn();
+
+  const supabase = {
+    auth: {
+      signInWithPassword,
+      signInWithOAuth,
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signInWithPassword.mockResolvedValue({ error: null });
+    signInWithOAuth.mockResolvedValue({ error: null });
+  });
+
+  test('submits email login credentials and closes on success', async () => {
+    render(<Login supabase={supabase} onSuccess={onSuccess} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(signInWithPassword).toHaveBeenCalledWith({
+        email: 'player@example.com',
+        password: 'secret123',
+      });
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows the Supabase error message when email login fails', async () => {
+    signInWithPassword.mockResolvedValue({
+      error: new Error('Invalid login credentials'),
+    });
+
+    render(<Login supabase={supabase} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'wrong-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText('Invalid login credentials')).toBeInTheDocument();
+  });
+
+  test('starts Google OAuth with the current origin as the redirect target', async () => {
+    render(<Login supabase={supabase} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^google$/i }));
+
+    await waitFor(() => {
+      expect(signInWithOAuth).toHaveBeenCalledWith({
+        provider: 'google',
+        options: {
+          redirectTo: window.location.origin,
+        },
+      });
+    });
+  });
+
+  test('shows a provider-specific error when Apple OAuth fails', async () => {
+    signInWithOAuth.mockResolvedValue({
+      error: new Error('Apple OAuth is not configured'),
+    });
+
+    render(<Login supabase={supabase} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^apple$/i }));
+
+    expect(await screen.findByText('Apple OAuth is not configured')).toBeInTheDocument();
+  });
+});

--- a/src/components/auth/ResetPassword.test.tsx
+++ b/src/components/auth/ResetPassword.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import ResetPassword from './ResetPassword';
+
+describe('ResetPassword', () => {
+  const resetPasswordForEmail = vi.fn();
+  const updateUser = vi.fn();
+  const supabase = {
+    auth: {
+      resetPasswordForEmail,
+      updateUser,
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '';
+    resetPasswordForEmail.mockResolvedValue({ error: null });
+    updateUser.mockResolvedValue({ error: null });
+  });
+
+  test('sends a reset link to the provided email', async () => {
+    render(<ResetPassword supabase={supabase} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(resetPasswordForEmail).toHaveBeenCalledWith('player@example.com', {
+        redirectTo: window.location.origin,
+      });
+    });
+    expect(
+      await screen.findByText('Password reset instructions sent to your email!'),
+    ).toBeInTheDocument();
+  });
+
+  test('does not submit password update when the confirmation does not match', async () => {
+    window.location.hash = '#access_token=test&type=recovery';
+
+    render(<ResetPassword supabase={supabase} />);
+
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'different123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(updateUser).not.toHaveBeenCalled();
+    expect(await screen.findByText("Passwords don't match")).toBeInTheDocument();
+  });
+
+  test('updates the password during recovery flow and clears the recovery hash', async () => {
+    window.location.hash = '#access_token=test&type=recovery';
+
+    render(<ResetPassword supabase={supabase} />);
+
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledWith({
+        password: 'secret123',
+      });
+    });
+    expect(await screen.findByText('Password updated successfully!')).toBeInTheDocument();
+    expect(window.location.hash).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression coverage for login email and social auth flows
- add reset password coverage for reset-link and recovery update flows
- wait for async loading in GameStatistics test to remove noisy test warnings

## Linked issues
- Closes #42
- Progress on #31

## Testing
- npm run test