### PR TITLE
🧪 Expand test coverage for core hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # migration/planning artifacts
 /.migration
+/.claude
 
 # misc
 .DS_Store

--- a/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
+++ b/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { createMockGameData } from '../../../../testing/factories';
+import { useGameHistory } from '../useGameHistory';
+
+const createQuery = (result: unknown) => {
+  const query = {
+    select: vi.fn(() => query),
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    update: vi.fn(() => query),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  };
+
+  return query;
+};
+
+const createSupabase = (query: ReturnType<typeof createQuery>) => ({
+  from: vi.fn(() => query),
+  channel: vi.fn(() => ({
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn(() => ({ id: 'subscription' })),
+  })),
+  removeChannel: vi.fn(),
+});
+
+describe('useGameHistory', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_DISABLE_SUPABASE_REALTIME', 'true');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('loads valid games from Supabase ordered by date', async () => {
+    const validGame = createMockGameData({ id: 'valid-game' });
+    const invalidGame = { id: 'invalid-game', players: [] };
+    const query = createQuery({ data: [validGame, invalidGame], error: null });
+    const supabase = createSupabase(query);
+
+    const { result } = renderHook(() =>
+      useGameHistory({ supabase: supabase as never, user: null }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(supabase.from).toHaveBeenCalledWith('games');
+    expect(query.eq).toHaveBeenCalledWith('deleted', false);
+    expect(query.order).toHaveBeenCalledWith('date', { ascending: false });
+    expect(result.current.games).toEqual([validGame]);
+    expect(result.current.error).toBe('');
+  });
+
+  test('filters authenticated queries by owner id', async () => {
+    const query = createQuery({ data: [], error: null });
+    const supabase = createSupabase(query);
+    const user = { id: 'user-1' };
+
+    const { result } = renderHook(() =>
+      useGameHistory({
+        supabase: supabase as never,
+        user: user as never,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(query.eq).toHaveBeenCalledWith('owner_id', 'user-1');
+  });
+
+  test('sets an error when loading games fails', async () => {
+    const query = createQuery({ data: null, error: new Error('load failed') });
+    const supabase = createSupabase(query);
+
+    const { result } = renderHook(() =>
+      useGameHistory({ supabase: supabase as never, user: null }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe('Failed to load game history');
+    expect(result.current.games).toEqual([]);
+  });
+
+  test('soft deletes a game and removes it from local state', async () => {
+    const game = createMockGameData({ id: 'game-to-delete' });
+    const query = createQuery({ data: [game], error: null });
+    const deleteQuery = createQuery({ error: null });
+    const supabase = createSupabase(query);
+    supabase.from.mockReturnValueOnce(query).mockReturnValueOnce(deleteQuery);
+
+    const { result } = renderHook(() =>
+      useGameHistory({ supabase: supabase as never, user: null }),
+    );
+
+    await waitFor(() => expect(result.current.games).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.deleteGame('game-to-delete');
+    });
+
+    expect(deleteQuery.update).toHaveBeenCalledWith({ deleted: true });
+    expect(deleteQuery.eq).toHaveBeenCalledWith('id', 'game-to-delete');
+    expect(result.current.games).toEqual([]);
+  });
+});

--- a/src/components/GameHistory/hooks/__tests__/useGameSelection.test.ts
+++ b/src/components/GameHistory/hooks/__tests__/useGameSelection.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { createMockGameData } from '../../../../testing/factories';
+import { useGameSelection } from '../useGameSelection';
+
+describe('useGameSelection', () => {
+  const games = [
+    createMockGameData({ id: 'game-1' }),
+    createMockGameData({ id: 'game-2' }),
+  ];
+
+  test('initializes with no selected game or pending delete', () => {
+    const { result } = renderHook(() => useGameSelection({ games }));
+
+    expect(result.current.selectedGameId).toBeNull();
+    expect(result.current.selectedGame).toBeNull();
+    expect(result.current.showDeleteConfirmation).toBe(false);
+    expect(result.current.gameToDelete).toBeNull();
+  });
+
+  test('selects a game by id', () => {
+    const { result } = renderHook(() => useGameSelection({ games }));
+
+    act(() => {
+      result.current.handleGameSelect('game-2');
+    });
+
+    expect(result.current.selectedGameId).toBe('game-2');
+    expect(result.current.selectedGame?.id).toBe('game-2');
+  });
+
+  test('opens and cancels delete confirmation', () => {
+    const { result } = renderHook(() => useGameSelection({ games }));
+
+    act(() => {
+      result.current.confirmDelete('game-1');
+    });
+
+    expect(result.current.showDeleteConfirmation).toBe(true);
+    expect(result.current.gameToDelete).toBe('game-1');
+
+    act(() => {
+      result.current.cancelDelete();
+    });
+
+    expect(result.current.showDeleteConfirmation).toBe(false);
+    expect(result.current.gameToDelete).toBeNull();
+  });
+
+  test('deselects only when the selected game is deleted', () => {
+    const { result } = renderHook(() => useGameSelection({ games }));
+
+    act(() => {
+      result.current.handleGameSelect('game-2');
+    });
+
+    act(() => {
+      result.current.confirmDelete('game-1');
+    });
+
+    act(() => {
+      result.current.handleDeleteSuccess();
+    });
+
+    expect(result.current.selectedGameId).toBe('game-2');
+    expect(result.current.selectedGame?.id).toBe('game-2');
+
+    act(() => {
+      result.current.confirmDelete('game-2');
+    });
+
+    act(() => {
+      result.current.handleDeleteSuccess();
+    });
+
+    expect(result.current.selectedGameId).toBeNull();
+    expect(result.current.selectedGame).toBeNull();
+  });
+});

--- a/src/components/GameScoring/utils/calculations.test.ts
+++ b/src/components/GameScoring/utils/calculations.test.ts
@@ -1,0 +1,139 @@
+import { createMockGameAction, createMockPlayer } from '../../../testing/factories';
+
+import {
+  calculateGameDuration,
+  calculatePlayerStats,
+  calculatePointsInInning,
+} from './calculations';
+
+describe('GameScoring calculations', () => {
+  describe('calculatePlayerStats', () => {
+    test('calculates BPI and shooting percentage from player totals', () => {
+      const stats = calculatePlayerStats(
+        createMockPlayer({
+          id: 1,
+          score: 30,
+          innings: 6,
+          safeties: 2,
+          missedShots: 3,
+          fouls: 1,
+        }),
+        [],
+      );
+
+      expect(stats).toMatchObject({
+        bpi: '5.00',
+        shootingPercentage: 83,
+        safetyEfficiency: 0,
+      });
+    });
+
+    test('counts safeties followed by opponent misses or fouls as successful', () => {
+      const stats = calculatePlayerStats(
+        createMockPlayer({ id: 1, score: 10, innings: 4, safeties: 2 }),
+        [
+          createMockGameAction({ type: 'safety', playerId: 1, value: 0 }),
+          createMockGameAction({ type: 'miss', playerId: 2, value: 0 }),
+          createMockGameAction({ type: 'safety', playerId: 1, value: 0 }),
+          createMockGameAction({ type: 'foul', playerId: 2, value: -1 }),
+        ],
+      );
+
+      expect(stats.successfulSafeties).toBe(2);
+      expect(stats.safetyEfficiency).toBe(100);
+      expect(stats.offensiveBPI).toBe('5.00');
+    });
+
+    test('handles zero innings and zero shot attempts without NaN values', () => {
+      const stats = calculatePlayerStats(
+        createMockPlayer({
+          score: 0,
+          innings: 0,
+          safeties: 0,
+          missedShots: 0,
+          fouls: 0,
+        }),
+        [],
+      );
+
+      expect(stats.bpi).toBe('0.00');
+      expect(stats.shootingPercentage).toBe(0);
+      expect(stats.safetyEfficiency).toBe(0);
+    });
+  });
+
+  describe('calculateGameDuration', () => {
+    test('returns N/A for games with no actions', () => {
+      expect(calculateGameDuration([])).toBe('N/A');
+    });
+
+    test('formats elapsed minutes and seconds across action timestamps', () => {
+      expect(
+        calculateGameDuration([
+          createMockGameAction({ timestamp: new Date('2026-01-01T00:00:00Z') }),
+          createMockGameAction({ timestamp: new Date('2026-01-01T00:03:42Z') }),
+        ]),
+      ).toBe('3m 42s');
+    });
+  });
+
+  describe('calculatePointsInInning', () => {
+    test('adds the current run when the player has no prior scoring action', () => {
+      const points = calculatePointsInInning(
+        [],
+        1,
+        4,
+        15,
+        createMockGameAction({
+          type: 'miss',
+          playerId: 1,
+          value: 0,
+          ballsOnTable: 12,
+        }),
+      );
+
+      expect(points).toBe(7);
+    });
+
+    test('uses only final-shot balls once prior score actions exist', () => {
+      const points = calculatePointsInInning(
+        [
+          createMockGameAction({
+            type: 'score',
+            playerId: 1,
+            value: 5,
+            ballsOnTable: 10,
+          }),
+        ],
+        1,
+        5,
+        10,
+        createMockGameAction({
+          type: 'miss',
+          playerId: 1,
+          value: 0,
+          ballsOnTable: 8,
+        }),
+      );
+
+      expect(points).toBe(2);
+    });
+
+    test('subtracts a foul penalty from final inning points', () => {
+      const points = calculatePointsInInning(
+        [],
+        1,
+        3,
+        15,
+        createMockGameAction({
+          type: 'foul',
+          playerId: 1,
+          value: -1,
+          ballsOnTable: 14,
+        }),
+      );
+
+      expect(points).toBe(3);
+    });
+  });
+});

--- a/src/hooks/__tests__/useFullscreen.test.ts
+++ b/src/hooks/__tests__/useFullscreen.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { useFullscreen } from '../useFullscreen';
+
+const addError = vi.fn();
+
+vi.mock('../../context/ErrorContext', () => ({
+  useError: () => ({ addError }),
+}));
+
+const setDocumentProperty = (property: keyof Document, value: unknown) => {
+  Object.defineProperty(document, property, {
+    configurable: true,
+    value,
+  });
+};
+
+describe('useFullscreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDocumentProperty('fullscreenElement', null);
+    setDocumentProperty('exitFullscreen', vi.fn());
+    document.documentElement.requestFullscreen = vi.fn();
+  });
+
+  test('starts outside fullscreen mode', () => {
+    const { result } = renderHook(() => useFullscreen());
+
+    expect(result.current.isFullScreen).toBe(false);
+  });
+
+  test('requests fullscreen when not currently fullscreen', async () => {
+    const requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    document.documentElement.requestFullscreen = requestFullscreen;
+    const { result } = renderHook(() => useFullscreen());
+
+    await act(async () => {
+      await result.current.toggleFullscreen();
+    });
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  test('exits fullscreen when already fullscreen', async () => {
+    const exitFullscreen = vi.fn().mockResolvedValue(undefined);
+    setDocumentProperty('fullscreenElement', document.documentElement);
+    setDocumentProperty('exitFullscreen', exitFullscreen);
+    const { result } = renderHook(() => useFullscreen());
+
+    await act(async () => {
+      await result.current.toggleFullscreen();
+    });
+
+    expect(exitFullscreen).toHaveBeenCalledTimes(1);
+  });
+
+  test('updates fullscreen state from fullscreenchange events', () => {
+    const { result } = renderHook(() => useFullscreen());
+
+    act(() => {
+      setDocumentProperty('fullscreenElement', document.documentElement);
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(result.current.isFullScreen).toBe(true);
+
+    act(() => {
+      setDocumentProperty('fullscreenElement', null);
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(result.current.isFullScreen).toBe(false);
+  });
+
+  test('reports unsupported fullscreen errors', async () => {
+    document.documentElement.requestFullscreen = undefined;
+    const { result } = renderHook(() => useFullscreen());
+
+    await act(async () => {
+      await result.current.toggleFullscreen();
+    });
+
+    expect(addError).toHaveBeenCalledWith(
+      'Unable to toggle fullscreen. Your browser may not support this feature.',
+    );
+  });
+});

--- a/src/hooks/__tests__/useGameSettings.test.ts
+++ b/src/hooks/__tests__/useGameSettings.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { DEFAULT_SHOT_CLOCK_SECONDS } from '../../constants/gameSettings';
+import { useGameSettings } from '../useGameSettings';
+
+describe('useGameSettings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('initializes default settings when localStorage is empty', () => {
+    const { result } = renderHook(() => useGameSettings());
+
+    expect(result.current.lastPlayers).toEqual([]);
+    expect(result.current.lastPlayerTargetScores).toEqual({});
+    expect(result.current.lastBreakingPlayerId).toBe(0);
+    expect(result.current.lastShotClockSeconds).toBe(DEFAULT_SHOT_CLOCK_SECONDS);
+  });
+
+  test('restores saved settings from localStorage', () => {
+    localStorage.setItem('runcount_lastPlayers', JSON.stringify(['Alice', 'Bob']));
+    localStorage.setItem(
+      'runcount_lastPlayerTargetScores',
+      JSON.stringify({ Alice: 75, Bob: 60 }),
+    );
+    localStorage.setItem('runcount_lastBreakingPlayerId', JSON.stringify(1));
+    localStorage.setItem('runcount_lastShotClockSeconds', JSON.stringify(null));
+
+    const { result } = renderHook(() => useGameSettings());
+
+    expect(result.current.lastPlayers).toEqual(['Alice', 'Bob']);
+    expect(result.current.lastPlayerTargetScores).toEqual({ Alice: 75, Bob: 60 });
+    expect(result.current.lastBreakingPlayerId).toBe(1);
+    expect(result.current.lastShotClockSeconds).toBeNull();
+  });
+
+  test('persists updates while preserving empty players and target score guards', () => {
+    const { result } = renderHook(() => useGameSettings());
+
+    act(() => {
+      result.current.setLastPlayers(['Alice', 'Bob']);
+      result.current.setLastPlayerTargetScores({ Alice: 75, Bob: 60 });
+      result.current.setLastBreakingPlayerId(1);
+      result.current.setLastShotClockSeconds(45);
+    });
+
+    expect(localStorage.getItem('runcount_lastPlayers')).toBe(
+      JSON.stringify(['Alice', 'Bob']),
+    );
+    expect(localStorage.getItem('runcount_lastPlayerTargetScores')).toBe(
+      JSON.stringify({ Alice: 75, Bob: 60 }),
+    );
+    expect(localStorage.getItem('runcount_lastBreakingPlayerId')).toBe('1');
+    expect(localStorage.getItem('runcount_lastShotClockSeconds')).toBe('45');
+
+    act(() => {
+      result.current.setLastPlayers([]);
+      result.current.setLastPlayerTargetScores({});
+    });
+
+    expect(localStorage.getItem('runcount_lastPlayers')).toBe(
+      JSON.stringify(['Alice', 'Bob']),
+    );
+    expect(localStorage.getItem('runcount_lastPlayerTargetScores')).toBe(
+      JSON.stringify({ Alice: 75, Bob: 60 }),
+    );
+  });
+});

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -1,0 +1,118 @@
+import { act, renderHook } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { createMockGameData, createMockPlayer } from '../../testing/factories';
+import { useGameState } from '../useGameState';
+
+const getGameState = vi.fn();
+const clearGameState = vi.fn();
+let hasActiveGame = false;
+
+vi.mock('../../context/GamePersistContext', () => ({
+  useGamePersist: () => ({
+    getGameState,
+    clearGameState,
+    hasActiveGame,
+  }),
+}));
+
+describe('useGameState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hasActiveGame = false;
+    getGameState.mockReturnValue(null);
+  });
+
+  test('initializes to setup when there is no saved game', () => {
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.gameState).toBe('setup');
+    expect(result.current.players).toEqual([]);
+    expect(result.current.currentGameId).toBeNull();
+  });
+
+  test('restores an incomplete saved game into scoring state', () => {
+    getGameState.mockReturnValue(
+      createMockGameData({
+        id: 'saved-game',
+        completed: false,
+        players: [
+          createMockPlayer({ id: 0, name: 'Alice', targetScore: 75 }),
+          createMockPlayer({ id: 1, name: 'Bob', targetScore: 60 }),
+        ],
+        startTime: '2026-01-01T00:00:00.000Z',
+        turnStartTime: '2026-01-01T00:01:00.000Z',
+      }),
+    );
+
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.gameState).toBe('scoring');
+    expect(result.current.players).toEqual(['Alice', 'Bob']);
+    expect(result.current.playerTargetScores).toEqual({ Alice: 75, Bob: 60 });
+    expect(result.current.currentGameId).toBe('saved-game');
+    expect(result.current.matchStartTime?.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.current.turnStartTime?.toISOString()).toBe('2026-01-01T00:01:00.000Z');
+  });
+
+  test('clears completed active saved games and stays on setup', () => {
+    hasActiveGame = true;
+    getGameState.mockReturnValue(createMockGameData({ completed: true }));
+
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.gameState).toBe('setup');
+    expect(clearGameState).toHaveBeenCalledTimes(1);
+  });
+
+  test('transitions through setup, scoring, statistics, and history handlers', () => {
+    const onSaveSettings = vi.fn();
+    const { result } = renderHook(() => useGameState());
+
+    act(() => {
+      result.current.handleStartGame(
+        ['Alice', 'Bob'],
+        { Alice: 75, Bob: 60 },
+        1,
+        onSaveSettings,
+      );
+    });
+
+    expect(result.current.gameState).toBe('scoring');
+    expect(result.current.breakingPlayerId).toBe(1);
+    expect(onSaveSettings).toHaveBeenCalledWith(
+      ['Alice', 'Bob'],
+      { Alice: 75, Bob: 60 },
+      1,
+    );
+
+    act(() => {
+      result.current.handleFinishGame();
+    });
+
+    expect(result.current.gameState).toBe('statistics');
+
+    act(() => {
+      result.current.handleViewHistory();
+    });
+
+    expect(result.current.gameState).toBe('history');
+
+    act(() => {
+      result.current.handleStartNewGame();
+    });
+
+    expect(result.current.gameState).toBe('setup');
+    expect(result.current.currentGameId).toBeNull();
+  });
+
+  test('responds to switchToHistory window events', () => {
+    const { result } = renderHook(() => useGameState());
+
+    act(() => {
+      window.dispatchEvent(new Event('switchToHistory'));
+    });
+
+    expect(result.current.gameState).toBe('history');
+  });
+});

--- a/src/hooks/__tests__/useTheme.test.ts
+++ b/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,39 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useTheme } from '../useTheme';
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  test('defaults to dark mode and persists the preference', () => {
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.darkMode).toBe(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem('runcount_theme')).toBe('dark');
+  });
+
+  test('restores light mode from localStorage', () => {
+    localStorage.setItem('runcount_theme', 'light');
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.darkMode).toBe(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  test('toggles dark mode and updates localStorage and the document class', () => {
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.toggleDarkMode();
+    });
+
+    expect(result.current.darkMode).toBe(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem('runcount_theme')).toBe('light');
+  });
+});

--- a/src/testing/factories.ts
+++ b/src/testing/factories.ts
@@ -1,4 +1,4 @@
-import { type Player } from '../types/game';
+import { type GameAction, type GameData, type Player } from '../types/game';
 
 export const createMockPlayer = (overrides: Partial<Player> = {}): Player => ({
   id: 1,
@@ -11,5 +11,30 @@ export const createMockPlayer = (overrides: Partial<Player> = {}): Player => ({
   safeties: 0,
   missedShots: 0,
   targetScore: 75,
+  ...overrides,
+});
+
+export const createMockGameAction = (
+  overrides: Partial<GameAction> = {},
+): GameAction => ({
+  type: 'score',
+  playerId: 1,
+  value: 1,
+  timestamp: new Date('2026-01-01T00:00:00.000Z'),
+  ballsOnTable: 15,
+  ...overrides,
+});
+
+export const createMockGameData = (overrides: Partial<GameData> = {}): GameData => ({
+  id: 'game-1',
+  date: '2026-01-01T00:00:00.000Z',
+  players: [
+    createMockPlayer({ id: 0, name: 'Alice', targetScore: 75 }),
+    createMockPlayer({ id: 1, name: 'Bob', targetScore: 75 }),
+  ],
+  winner_id: null,
+  completed: false,
+  actions: [],
+  deleted: false,
   ...overrides,
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
       VITE_SUPABASE_URL: 'https://test.supabase.co',
       VITE_SUPABASE_KEY: 'test-dummy-key-for-ci-testing',
     },
-    exclude: ['tests/**', 'node_modules/**', '**/node_modules/**'],
+    exclude: ['.claude/**', 'tests/**', 'node_modules/**', '**/node_modules/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'json-summary'],


### PR DESCRIPTION
## Summary
- Adds shared test factories for game actions and game data.
- Adds coverage for scoring calculation utilities, game history hooks, app-level hooks, theme, fullscreen, and game settings.
- Excludes local `.claude` worktrees from Vitest discovery and git tracking to avoid accidental duplicate test collection.

## Linked Issue
Closes #31

## Validation
- `npm run test` — 39 files, 208 tests passed
- `npm run lint`
- `npm run build`
- Pre-push hook: `npm run lint && npm run test` passed during `git push`