### PR TITLE
💄 Standardize page-title styling across History, Trends, Profile

### DIFF
--- a/src/components/GameHistory/index.tsx
+++ b/src/components/GameHistory/index.tsx
@@ -179,10 +179,22 @@ const GameHistory: React.FC<GameHistoryProps> = ({
         onConfirm={() => gameToDelete && handleDeleteGame(gameToDelete)}
       />
 
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold">
-          Game History {validGameCount > 0 ? `(${validGameCount})` : ''}
-        </h2>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="text-center sm:text-left">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Past Games
+          </p>
+          <div className="mt-1 flex flex-wrap items-baseline justify-center gap-x-2 sm:justify-start">
+            <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
+              Game History
+            </h2>
+            {validGameCount > 0 && (
+              <span className="text-base font-medium text-gray-500 dark:text-gray-400">
+                ({validGameCount})
+              </span>
+            )}
+          </div>
+        </div>
         <div className="flex gap-2">
           {viewTrends && (
             <button

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -140,7 +140,14 @@ export const GameRouter: FC<GameRouterProps> = ({
     case 'trends':
       return <TrendsPage supabase={supabase} user={user} onStartNewGame={onGoToSetup} />;
     case 'profile':
-      return <UserProfile supabase={supabase} user={user!} onSignOut={onSignOut} />;
+      return (
+        <UserProfile
+          supabase={supabase}
+          user={user!}
+          onSignOut={onSignOut}
+          showPageTitle
+        />
+      );
     default:
       return <GameSetup startGame={onStartGame} />;
   }

--- a/src/components/Trends/index.tsx
+++ b/src/components/Trends/index.tsx
@@ -80,8 +80,15 @@ const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => 
 
   return (
     <div className="max-w-5xl mx-auto">
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold">Trends</h2>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="text-center sm:text-left">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Performance
+          </p>
+          <h2 className="mt-1 text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
+            Trends
+          </h2>
+        </div>
         <button
           onClick={onStartNewGame}
           className="px-4 py-2 bg-blue-600 dark:bg-blue-700 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-800"

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -6,6 +6,7 @@ interface UserProfileProps {
   supabase: SupabaseClient;
   user: User;
   onSignOut: () => Promise<void>;
+  showPageTitle?: boolean;
 }
 
 const getErrorMessage = (error: unknown, fallback = 'An error occurred') => {
@@ -15,7 +16,12 @@ const getErrorMessage = (error: unknown, fallback = 'An error occurred') => {
   return fallback;
 };
 
-const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) => {
+const UserProfile: React.FC<UserProfileProps> = ({
+  supabase,
+  user,
+  onSignOut,
+  showPageTitle = false,
+}) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -87,233 +93,245 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
   };
 
   return (
-    <div className="w-[300px] mx-auto bg-white dark:bg-gray-800 rounded shadow-md">
-      <div className="p-3 dark:text-gray-100">
-        {error && (
-          <div className="bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
-            {error}
-          </div>
-        )}
-
-        {message && (
-          <div className="bg-green-100 dark:bg-green-900/30 border border-green-400 dark:border-green-700 text-green-700 dark:text-green-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
-            {message}
-          </div>
-        )}
-
-        {/* Update Email Form */}
-        <div className="mb-4">
-          <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
-            Update Email
-          </h3>
-          <div className="mb-2">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Current Email
-            </label>
-            <p className="text-sm text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-700 px-2 py-1.5 rounded border">
-              {user.email}
-            </p>
-          </div>
-          <form onSubmit={handleUpdateEmail} className="space-y-2">
-            <div>
-              <label
-                htmlFor="new-email"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                New Email
-              </label>
-              <input
-                id="new-email"
-                type="email"
-                value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
-                required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Enter new email"
-                disabled={loading}
-              />
-            </div>
-
-            <button
-              type="submit"
-              className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <svg
-                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Updating...
-                </>
-              ) : (
-                'Update Email'
-              )}
-            </button>
-          </form>
+    <>
+      {showPageTitle && (
+        <div className="mb-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+            Your Account
+          </p>
+          <h1 className="mt-1 text-2xl sm:text-3xl font-bold text-gray-900 dark:text-white">
+            My Profile
+          </h1>
         </div>
-
-        {/* Update Password Form */}
-        <div className="mb-4">
-          <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
-            Update Password
-          </h3>
-          <form onSubmit={handleUpdatePassword} className="space-y-2">
-            <div>
-              <label
-                htmlFor="new-password"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                New Password
-              </label>
-              <input
-                id="new-password"
-                type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Enter new password"
-                disabled={loading}
-              />
+      )}
+      <div className="w-[300px] mx-auto bg-white dark:bg-gray-800 rounded shadow-md">
+        <div className="p-3 dark:text-gray-100">
+          {error && (
+            <div className="bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
+              {error}
             </div>
+          )}
 
-            <div>
-              <label
-                htmlFor="confirm-password"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                Confirm Password
-              </label>
-              <input
-                id="confirm-password"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Confirm new password"
-                disabled={loading}
-              />
+          {message && (
+            <div className="bg-green-100 dark:bg-green-900/30 border border-green-400 dark:border-green-700 text-green-700 dark:text-green-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
+              {message}
             </div>
+          )}
 
-            <button
-              type="submit"
-              className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <svg
-                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Updating...
-                </>
-              ) : (
-                'Update Password'
-              )}
-            </button>
-          </form>
-        </div>
-
-        {/* Sign Out Button */}
-        <button
-          onClick={() => setShowSignOutConfirm(true)}
-          className="w-full bg-red-600 text-white py-1.5 px-2 rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm"
-        >
-          Sign Out
-        </button>
-      </div>
-
-      {/* Sign Out Confirmation Modal */}
-      {showSignOutConfirm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded p-4 w-[320px] mx-4">
-            <h3 className="text-base font-medium text-gray-900 dark:text-white mb-3">
-              Confirm Sign Out
+          {/* Update Email Form */}
+          <div className="mb-4">
+            <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
+              Update Email
             </h3>
-            <p className="text-gray-600 dark:text-gray-300 mb-4 text-sm">
-              Are you sure you want to sign out?
-            </p>
-            <div className="flex justify-end space-x-2">
-              <button
-                onClick={() => setShowSignOutConfirm(false)}
-                className="px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white text-sm"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleSignOut}
-                className="px-3 py-1.5 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 text-sm"
-              >
-                Sign Out
-              </button>
+            <div className="mb-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Current Email
+              </label>
+              <p className="text-sm text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-700 px-2 py-1.5 rounded border">
+                {user.email}
+              </p>
             </div>
-          </div>
-        </div>
-      )}
+            <form onSubmit={handleUpdateEmail} className="space-y-2">
+              <div>
+                <label
+                  htmlFor="new-email"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  New Email
+                </label>
+                <input
+                  id="new-email"
+                  type="email"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  required
+                  className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
+                  placeholder="Enter new email"
+                  disabled={loading}
+                />
+              </div>
 
-      {/* Success Animation */}
-      {showSuccessAnimation && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 text-center">
-            <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg
-                className="w-8 h-8 text-green-500"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+              <button
+                type="submit"
+                className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
+                disabled={loading}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M5 13l4 4L19 7"
-                ></path>
-              </svg>
-            </div>
-            <p className="text-gray-900 dark:text-white font-medium">Success!</p>
-            <p className="text-gray-600 dark:text-gray-300 text-sm mt-2">
-              Your changes have been saved.
-            </p>
+                {loading ? (
+                  <>
+                    <svg
+                      className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    Updating...
+                  </>
+                ) : (
+                  'Update Email'
+                )}
+              </button>
+            </form>
           </div>
+
+          {/* Update Password Form */}
+          <div className="mb-4">
+            <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
+              Update Password
+            </h3>
+            <form onSubmit={handleUpdatePassword} className="space-y-2">
+              <div>
+                <label
+                  htmlFor="new-password"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  New Password
+                </label>
+                <input
+                  id="new-password"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
+                  placeholder="Enter new password"
+                  disabled={loading}
+                />
+              </div>
+
+              <div>
+                <label
+                  htmlFor="confirm-password"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  Confirm Password
+                </label>
+                <input
+                  id="confirm-password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
+                  placeholder="Confirm new password"
+                  disabled={loading}
+                />
+              </div>
+
+              <button
+                type="submit"
+                className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
+                disabled={loading}
+              >
+                {loading ? (
+                  <>
+                    <svg
+                      className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      ></circle>
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    Updating...
+                  </>
+                ) : (
+                  'Update Password'
+                )}
+              </button>
+            </form>
+          </div>
+
+          {/* Sign Out Button */}
+          <button
+            onClick={() => setShowSignOutConfirm(true)}
+            className="w-full bg-red-600 text-white py-1.5 px-2 rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm"
+          >
+            Sign Out
+          </button>
         </div>
-      )}
-    </div>
+
+        {/* Sign Out Confirmation Modal */}
+        {showSignOutConfirm && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white dark:bg-gray-800 rounded p-4 w-[320px] mx-4">
+              <h3 className="text-base font-medium text-gray-900 dark:text-white mb-3">
+                Confirm Sign Out
+              </h3>
+              <p className="text-gray-600 dark:text-gray-300 mb-4 text-sm">
+                Are you sure you want to sign out?
+              </p>
+              <div className="flex justify-end space-x-2">
+                <button
+                  onClick={() => setShowSignOutConfirm(false)}
+                  className="px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white text-sm"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSignOut}
+                  className="px-3 py-1.5 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 text-sm"
+                >
+                  Sign Out
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Success Animation */}
+        {showSuccessAnimation && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+            <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 text-center">
+              <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+                <svg
+                  className="w-8 h-8 text-green-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M5 13l4 4L19 7"
+                  ></path>
+                </svg>
+              </div>
+              <p className="text-gray-900 dark:text-white font-medium">Success!</p>
+              <p className="text-gray-600 dark:text-gray-300 text-sm mt-2">
+                Your changes have been saved.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Apply the same kicker + bold-title visual pattern used by Setup and Stats to the remaining top-level screens so they share one visual language:

- **History**: kicker `PAST GAMES` → **Game History** (count `(N)` kept inline as a muted span beside the title)
- **Trends**: kicker `PERFORMANCE` → **Trends**
- **Profile**: kicker `YOUR ACCOUNT` → **My Profile**

## Implementation notes

- Pattern: `text-xs font-semibold uppercase tracking-wider text-gray-400` kicker over a `text-2xl sm:text-3xl font-bold` title.
- History/Trends headers move from `flex justify-between` to a `flex-col sm:flex-row` layout so the title block stacks above the action buttons on mobile and sits next to them on wider screens.
- `UserProfile` gets an opt-in `showPageTitle` prop (default `false`) to avoid a double header inside `ProfileModal`, which already has its own header. `GameRouter` passes `showPageTitle` for the standalone `/profile` route.
- The History `(N)` valid-game count is preserved inline next to the title.

## Test plan

- [x] `npx tsc --noEmit` — no new errors in touched files
- [x] `vitest run` for `Trends/__tests__/TrendsPage.test.tsx`, `App.test.tsx`, `App.start-game.test.tsx`, `__tests__/app.flow.integration.test.tsx` — all pass
- [x] `npm run build` — clean production build
- [ ] Manual visual check: History page, Trends page, Profile page (route), Profile modal (no double header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)