### PR TITLE
Refresh app design (6 screens) + bootstrap fresh Supabase project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Copy this file to .env and fill in real values for local development.
+#
+# Vite only exposes env vars prefixed with VITE_ to the client bundle. The
+# legacy REACT_APP_* prefix from the Create React App era is ignored — if
+# you have an old .env using REACT_APP_*, rename the keys here.
+
+# --- Required: Supabase project credentials -------------------------------
+# Get these from your Supabase project dashboard:
+#   Settings → API → Project URL  → VITE_SUPABASE_URL
+#   Settings → API → anon / public → VITE_SUPABASE_KEY
+# The anon key is safe to embed in client bundles (RLS gates actual access).
+VITE_SUPABASE_URL=
+VITE_SUPABASE_KEY=
+
+# --- Optional: error tracking ---------------------------------------------
+# Leave blank to disable Sentry locally.
+VITE_SENTRY_DSN=
+
+# --- Optional: testing knobs ----------------------------------------------
+# Set to "true" to disable the realtime postgres_changes subscription on
+# the History screen (used in some test environments).
+VITE_DISABLE_SUPABASE_REALTIME=

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 .env*
+!.env.example
 .migration
 
 npm-debug.log*

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,8 +79,10 @@ describe('App Component', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
+    // The modal opens on the Login tab by default; the per-tab header
+    // replaced the old generic "Authentication" title.
     await waitFor(() => {
-      expect(screen.getByText('Authentication')).toBeInTheDocument();
+      expect(screen.getByText('Welcome back')).toBeInTheDocument();
     });
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -74,33 +74,28 @@ describe('App Component', () => {
     });
   });
 
-  test('opens Authentication modal when clicking user icon (unauthenticated)', async () => {
+  test('opens Authentication modal when clicking Sign in (unauthenticated)', async () => {
     render(<App />);
 
-    fireEvent.click(screen.getByRole('button', { name: /open authentication modal/i }));
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Authentication')).toBeInTheDocument();
     });
   });
 
-  test('shows navigation tab for New Game when not scoring', async () => {
+  test('hides the navigation bar when not authenticated', async () => {
     render(<App />);
 
+    // The setup screen renders, but the top-level nav should not — when only "New Game"
+    // is the available tab (signed-out), the nav is hidden as redundant chrome.
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /New Game/i })).toBeInTheDocument();
+      expect(screen.getByTestId('game-setup')).toBeInTheDocument();
     });
-  });
 
-  test('displays correct navigation labels when not authenticated', async () => {
-    render(<App />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /New Game/i })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /History/i })).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /My Profile/i }),
-      ).not.toBeInTheDocument();
-    });
+    expect(screen.queryByRole('button', { name: /^New Game$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /History/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Trends/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /My Profile/i })).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/app.end-game.integration.test.tsx
+++ b/src/__tests__/app.end-game.integration.test.tsx
@@ -102,9 +102,11 @@ describe('App end-game flow', () => {
     await userEvent.click(await screen.findByRole('button', { name: /Continue/i }));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: /Game Statistics/i }),
-      ).toBeInTheDocument();
+      // The Statistics screen renders the GameSummaryPanel and a contextual
+      // 'Game Result' label; the prior 'Game Statistics' h2 was replaced by a
+      // result headline (e.g. "<Player> wins").
+      expect(screen.getByTestId('game-summary-panel')).toBeInTheDocument();
+      expect(screen.getByText(/Game Result/i)).toBeInTheDocument();
       expect(screen.getByText('Completed')).toBeInTheDocument();
       expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument();
     });
@@ -121,10 +123,10 @@ describe('App end-game flow', () => {
     await userEvent.click(confirmButtons[confirmButtons.length - 1]);
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: /Game Statistics/i }),
-      ).toBeInTheDocument();
-      expect(screen.getByText('Completed')).toBeInTheDocument();
+      // Manual end without anyone reaching target -> status is 'Ended', not 'Completed'.
+      expect(screen.getByTestId('game-summary-panel')).toBeInTheDocument();
+      expect(screen.getByText(/Game Result/i)).toBeInTheDocument();
+      expect(screen.getByText('Ended')).toBeInTheDocument();
       expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument();
     });
   });

--- a/src/__tests__/app.end-game.integration.test.tsx
+++ b/src/__tests__/app.end-game.integration.test.tsx
@@ -90,7 +90,8 @@ describe('App end-game flow', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /Start Game/i }));
 
-    await screen.findByRole('button', { name: /New Game/i });
+    // Wait for the scoring screen to mount: the End Game button is part of the utility row.
+    await screen.findByRole('button', { name: /^End Game$/i });
   };
 
   test('continues from the win screen without hitting the error boundary', async () => {
@@ -112,8 +113,12 @@ describe('App end-game flow', () => {
   test('ends a game manually without hitting the error boundary', async () => {
     await startGame();
 
-    await userEvent.click(screen.getByRole('button', { name: /New Game/i }));
-    await userEvent.click(screen.getByRole('button', { name: /^End Game$/i }));
+    // Open the End Game modal from the utility row, then confirm in the modal.
+    // (`getAllByRole` because both the row button and the modal confirm button match.)
+    const endGameButtons = screen.getAllByRole('button', { name: /^End Game$/i });
+    await userEvent.click(endGameButtons[0]);
+    const confirmButtons = await screen.findAllByRole('button', { name: /^End Game$/i });
+    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
 
     await waitFor(() => {
       expect(

--- a/src/components/GameHistory/components/GameDetails.tsx
+++ b/src/components/GameHistory/components/GameDetails.tsx
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 
 import { useError } from '../../../context/ErrorContext';
 import { type GameData } from '../../../types/game';
+import { computeMatchLength } from '../../../utils/computeMatchLength';
 import { copyWithFeedback } from '../../../utils/copyToClipboard';
+import { formatGameDateLong } from '../../../utils/formatGameDate';
 import { InningsModal } from '../../GameStatistics/components/InningsModal';
 import { StatDescriptionsModal } from '../../GameStatistics/components/StatDescriptionsModal';
 import { GameSummaryPanel } from '../../shared/GameSummaryPanel';
@@ -30,28 +32,13 @@ export const GameDetails: React.FC<GameDetailsProps> = ({
   const [showDescriptionsModal, setShowDescriptionsModal] = useState(false);
   const { addError } = useError();
 
-  // Calculate match length
-  const startTime = new Date(game.date);
-  const endTime = game.completed ? new Date(game.date) : new Date();
-  const diffMs = endTime.getTime() - startTime.getTime();
-  const hours = Math.floor(diffMs / (1000 * 60 * 60));
-  const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-  const matchLength = `${hours}h ${minutes}m`;
+  // Compute match length from real start/end timestamps. The previous
+  // inline calc used `game.date` for both endpoints, so completed games
+  // always rendered "0h 0m" — same bug we already fixed in GameStatistics.
+  const matchLength = computeMatchLength(game);
 
   const formatGameResultsForEmail = () => {
     if (!game) return '';
-
-    const gameDate = new Date(game.date);
-    const formattedDate = gameDate.toLocaleDateString('en-US', {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-    });
-    const formattedTime = gameDate.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
 
     // Sort players to show winner first
     const sortedPlayers = [...game.players].sort((a, b) => {
@@ -60,7 +47,7 @@ export const GameDetails: React.FC<GameDetailsProps> = ({
       return 0;
     });
 
-    let emailText = `${formattedDate} at ${formattedTime}\n`;
+    let emailText = `${formatGameDateLong(game.date)}\n`;
     emailText += `Length: ${matchLength}\n\n`;
 
     // Add player results

--- a/src/components/GameHistory/components/GameList.tsx
+++ b/src/components/GameHistory/components/GameList.tsx
@@ -1,108 +1,258 @@
 import React from 'react';
 
-import { type GameData } from '../../../types/game';
+import { type GameData, type Player } from '../../../types/game';
+import { computeMatchLength } from '../../../utils/computeMatchLength';
+import { formatGameDateTime } from '../../../utils/formatGameDate';
 
 interface GameListProps {
   games: GameData[];
-  selectedGameId: string | null;
+  totalGameCount: number;
   onGameSelect: (gameId: string) => void;
   onDeleteGame: (gameId: string) => void;
+  onStartNewGame: () => void;
 }
+
+/**
+ * Three status variants — kept in sync with GameSummaryPanel so the list
+ * card and the detail header agree about what the game looks like.
+ */
+const getStatus = (game: GameData) => {
+  const hasWinner = game.winner_id !== null && game.winner_id !== undefined;
+  if (!game.completed) {
+    return {
+      label: 'In Progress',
+      classes: 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200',
+    };
+  }
+  if (hasWinner) {
+    return {
+      label: 'Completed',
+      classes: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
+    };
+  }
+  return {
+    label: 'Ended',
+    classes: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200',
+  };
+};
+
+const sortByWinnerFirst = (players: Player[], winnerId: number | null | undefined) =>
+  [...players].sort((a, b) => {
+    if (a.id === winnerId) return -1;
+    if (b.id === winnerId) return 1;
+    return 0;
+  });
 
 export const GameList: React.FC<GameListProps> = ({
   games,
-  selectedGameId,
+  totalGameCount,
   onGameSelect,
   onDeleteGame,
+  onStartNewGame,
 }) => {
+  // Two empty states: filters hid everything (we have games, just none match)
+  // vs the user has no games at all (true first-run state). Previously both
+  // cases showed the same "No games match the current filters" copy, which
+  // misled first-time users into thinking they'd over-filtered.
   if (games.length === 0) {
+    if (totalGameCount === 0) {
+      return (
+        <div
+          className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-10 text-center"
+          data-testid="game-list-empty-zero"
+        >
+          <div
+            aria-hidden="true"
+            className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            No games yet
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Finish your first game and it'll show up here.
+          </p>
+          <button
+            onClick={onStartNewGame}
+            className="mt-5 inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold shadow-sm transition-colors"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            Start your first game
+          </button>
+        </div>
+      );
+    }
+
     return (
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center text-gray-600 dark:text-gray-300">
+      <div
+        className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-8 text-center text-gray-600 dark:text-gray-300"
+        data-testid="game-list-empty-filtered"
+      >
         No games match the current filters.
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-3" data-testid="game-list">
       {games.map((game) => {
-        const gameDate = new Date(game.date);
-        const formattedDate = gameDate.toLocaleDateString('en-US', {
-          weekday: 'long',
-          month: 'long',
-          day: 'numeric',
-        });
-        const formattedTime = gameDate.toLocaleTimeString('en-US', {
-          hour: 'numeric',
-          minute: '2-digit',
-          hour12: true,
-        });
+        const status = getStatus(game);
+        const sortedPlayers = sortByWinnerFirst(game.players, game.winner_id);
+        const matchLength = computeMatchLength(game);
+        const totalInnings = Math.max(...game.players.map((p) => p.innings));
 
         return (
-          <div
+          <button
             key={game.id}
-            className={`bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 cursor-pointer transition-colors ${
-              selectedGameId === game.id
-                ? 'border-2 border-blue-500'
-                : 'hover:bg-gray-50 dark:hover:bg-gray-700'
-            }`}
+            type="button"
             onClick={() => onGameSelect(game.id)}
+            className="group block w-full text-left bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md transition-all"
+            data-testid="game-list-item"
           >
-            <div className="flex justify-between items-start">
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                  {formattedDate} at {formattedTime}
-                </h3>
-                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                  {game.players.length} players
-                </p>
+            {/* Header: status + date + delete */}
+            <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-100 dark:border-gray-700">
+              <div className="flex items-center gap-3">
+                <span
+                  className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${status.classes}`}
+                >
+                  {status.label}
+                </span>
+                <span className="text-sm text-gray-500 dark:text-gray-400">
+                  {formatGameDateTime(game.date)}
+                </span>
               </div>
-              <div className="flex space-x-2">
-                <button
-                  onClick={(e) => {
+              <span
+                role="button"
+                tabIndex={0}
+                aria-label={`Delete game from ${formatGameDateTime(game.date)}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDeleteGame(game.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
                     e.stopPropagation();
                     onDeleteGame(game.id);
-                  }}
-                  className="text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                  }
+                }}
+                className="text-gray-400 hover:text-red-600 dark:hover:text-red-400 p-1 rounded transition-colors cursor-pointer"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
                 >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                    />
-                  </svg>
-                </button>
-              </div>
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                  />
+                </svg>
+              </span>
             </div>
-            <div className="mt-4">
-              <div className="grid grid-cols-2 gap-4">
-                {game.players.map((player) => (
-                  <div key={player.id} className="flex justify-between items-center">
-                    <span className="text-gray-700 dark:text-gray-300">
-                      {player.name}
-                    </span>
+
+            {/* Score rows */}
+            <div className="px-4 py-3 space-y-1.5">
+              {sortedPlayers.map((player) => {
+                const isWinner = player.id === game.winner_id;
+                return (
+                  <div key={player.id} className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {isWinner && (
+                        <span aria-hidden="true" className="text-sm">
+                          🏆
+                        </span>
+                      )}
+                      <span
+                        className={`truncate text-sm dark:text-white ${
+                          isWinner ? 'font-bold' : 'font-medium'
+                        }`}
+                      >
+                        {player.name}
+                      </span>
+                    </div>
                     <span
-                      className={`font-semibold ${
-                        player.id === game.winner_id
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-gray-900 dark:text-white'
+                      className={`font-mono text-sm tabular-nums ${
+                        isWinner
+                          ? 'text-blue-700 dark:text-blue-300 font-bold'
+                          : 'text-gray-900 dark:text-gray-200'
                       }`}
                     >
                       {player.score}
+                      <span className="text-gray-400 dark:text-gray-500">
+                        {' '}
+                        / {player.targetScore}
+                      </span>
                     </span>
                   </div>
-                ))}
-              </div>
+                );
+              })}
             </div>
-          </div>
+
+            {/* Footer: meta + view affordance */}
+            <div className="flex items-center justify-between px-4 py-2 border-t border-gray-100 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-700/20">
+              <div className="flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                <span>
+                  <span className="font-medium">Length:</span> {matchLength}
+                </span>
+                <span aria-hidden="true">·</span>
+                <span>
+                  <span className="font-medium">Innings:</span> {totalInnings}
+                </span>
+              </div>
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 dark:text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                View details
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-3 w-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </div>
+          </button>
         );
       })}
     </div>

--- a/src/components/GameHistory/index.tsx
+++ b/src/components/GameHistory/index.tsx
@@ -34,6 +34,12 @@ const GameHistory: React.FC<GameHistoryProps> = ({
 
   const filteredGames = filterAndSortGames(games, filters, sortOption);
 
+  // "Filter active" means the user has narrowed the list — drives whether
+  // we show the noisy "Showing X of Y" count line.
+  const isFilterActive =
+    JSON.stringify(filters) !== JSON.stringify(defaultHistoryFilters) ||
+    sortOption !== 'date-desc';
+
   // Function to check if games are valid
   const getValidGamesCount = () => {
     if (!games || !Array.isArray(games)) return 0;
@@ -183,131 +189,183 @@ const GameHistory: React.FC<GameHistoryProps> = ({
         <h2 className="text-2xl font-bold">
           Game History {validGameCount > 0 ? `(${validGameCount})` : ''}
         </h2>
-        <div className="flex gap-2">
-          {viewTrends && (
+        {/* Header CTAs only make sense once there's content; the empty
+            state below carries its own primary action. */}
+        {validGameCount > 0 && (
+          <div className="flex gap-2">
+            {viewTrends && (
+              <button
+                onClick={viewTrends}
+                className="px-4 py-2 bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-300 border border-blue-600 dark:border-blue-400 rounded-md hover:bg-blue-50 dark:hover:bg-gray-600"
+              >
+                View Trends →
+              </button>
+            )}
             <button
-              onClick={viewTrends}
-              className="px-4 py-2 bg-white dark:bg-gray-700 text-blue-700 dark:text-blue-300 border border-blue-600 dark:border-blue-400 rounded-md hover:bg-blue-50 dark:hover:bg-gray-600"
+              onClick={startNewGame}
+              className="px-4 py-2 bg-blue-600 dark:bg-blue-700 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-800"
             >
-              View Trends →
+              New Game
             </button>
-          )}
-          <button
-            onClick={startNewGame}
-            className="px-4 py-2 bg-blue-600 dark:bg-blue-700 text-white rounded-md hover:bg-blue-700 dark:hover:bg-blue-800"
-          >
-            New Game
-          </button>
-        </div>
+          </div>
+        )}
       </div>
 
       {/* Conditionally render either the list or details view */}
       {view === 'list' ? (
         <div className="min-h-[calc(100vh-15rem)]">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 mb-4 space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                From
-                <input
-                  aria-label="From"
-                  type="date"
-                  value={filters.startDate}
-                  onChange={(event) => updateFilter('startDate', event.target.value)}
-                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                />
-              </label>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                To
-                <input
-                  aria-label="To"
-                  type="date"
-                  value={filters.endDate}
-                  onChange={(event) => updateFilter('endDate', event.target.value)}
-                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                />
-              </label>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Opponent
-                <input
-                  aria-label="Opponent"
-                  type="search"
-                  value={filters.opponent}
-                  onChange={(event) => updateFilter('opponent', event.target.value)}
-                  placeholder="Player name"
-                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                />
-              </label>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Type
-                <select
-                  aria-label="Type"
-                  value={filters.gameType}
-                  onChange={(event) =>
-                    updateFilter(
-                      'gameType',
-                      event.target.value as HistoryFilters['gameType'],
-                    )
-                  }
-                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                >
-                  <option value="all">All games</option>
-                  <option value="completed">Completed</option>
-                  <option value="in-progress">In progress</option>
-                </select>
-              </label>
-              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                Sort
-                <select
-                  aria-label="Sort"
-                  value={sortOption}
-                  onChange={(event) =>
-                    setSortOption(event.target.value as HistorySortOption)
-                  }
-                  className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                >
-                  <option value="date-desc">Newest first</option>
-                  <option value="date-asc">Oldest first</option>
-                  <option value="winner">Winner</option>
-                  <option value="player-count">Player count</option>
-                  <option value="total-score-desc">Total score</option>
-                </select>
-              </label>
-            </div>
+          {/* Filter / export toolbar — hidden entirely when the user has
+              no games yet. The empty-state hero in GameList carries the
+              "start your first game" call to action; surfacing five date
+              inputs above it is noise. */}
+          {validGameCount > 0 && (
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 mb-4 space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-5 gap-3">
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  From
+                  <input
+                    aria-label="From"
+                    type="date"
+                    value={filters.startDate}
+                    onChange={(event) => updateFilter('startDate', event.target.value)}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  To
+                  <input
+                    aria-label="To"
+                    type="date"
+                    value={filters.endDate}
+                    onChange={(event) => updateFilter('endDate', event.target.value)}
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Opponent
+                  <input
+                    aria-label="Opponent"
+                    type="search"
+                    value={filters.opponent}
+                    onChange={(event) => updateFilter('opponent', event.target.value)}
+                    placeholder="Player name"
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  />
+                </label>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Type
+                  <select
+                    aria-label="Type"
+                    value={filters.gameType}
+                    onChange={(event) =>
+                      updateFilter(
+                        'gameType',
+                        event.target.value as HistoryFilters['gameType'],
+                      )
+                    }
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  >
+                    <option value="all">All games</option>
+                    <option value="completed">Completed</option>
+                    <option value="in-progress">In progress</option>
+                  </select>
+                </label>
+                <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Sort
+                  <select
+                    aria-label="Sort"
+                    value={sortOption}
+                    onChange={(event) =>
+                      setSortOption(event.target.value as HistorySortOption)
+                    }
+                    className="mt-1 w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                  >
+                    <option value="date-desc">Newest first</option>
+                    <option value="date-asc">Oldest first</option>
+                    <option value="winner">Winner</option>
+                    <option value="player-count">Player count</option>
+                    <option value="total-score-desc">Total score</option>
+                  </select>
+                </label>
+              </div>
 
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-sm text-gray-600 dark:text-gray-300">
-                Showing {filteredGames.length} of {validGameCount} games
-              </p>
-              <div className="flex flex-wrap gap-2">
-                <button
-                  onClick={resetFilters}
-                  className="px-3 py-2 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-white rounded-md hover:bg-gray-300 dark:hover:bg-gray-600"
-                >
-                  Reset
-                </button>
-                <button
-                  onClick={exportCsv}
-                  disabled={filteredGames.length === 0}
-                  className="px-3 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed"
-                >
-                  Export CSV
-                </button>
-                <button
-                  onClick={exportJson}
-                  disabled={filteredGames.length === 0}
-                  className="px-3 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed"
-                >
-                  Export JSON
-                </button>
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                {/* Counter only renders when a filter is actually narrowing the
+                    list; "Showing 1 of 1 games" against an empty filter form
+                    was redundant noise. */}
+                {isFilterActive ? (
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    Showing {filteredGames.length} of {validGameCount} games
+                  </p>
+                ) : (
+                  <span aria-hidden="true" />
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={resetFilters}
+                    disabled={!isFilterActive}
+                    className="px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    Reset
+                  </button>
+                  {/* Export buttons demoted from primary green/purple to a
+                      muted neutral with an icon; they're escape-hatches, not
+                      a primary action competing with the cards below. */}
+                  <button
+                    onClick={exportCsv}
+                    disabled={filteredGames.length === 0}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                      />
+                    </svg>
+                    Export CSV
+                  </button>
+                  <button
+                    onClick={exportJson}
+                    disabled={filteredGames.length === 0}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                      />
+                    </svg>
+                    Export JSON
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
+          )}
 
           <GameList
             games={filteredGames}
-            selectedGameId={null} // No game is selected in list view
+            totalGameCount={validGameCount}
             onGameSelect={handleSelectGame}
             onDeleteGame={confirmDelete}
+            onStartNewGame={startNewGame}
           />
         </div>
       ) : (

--- a/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
@@ -195,7 +195,7 @@ describe('GameScoring integration', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /\?\s*Help/i }));
+    await userEvent.click(screen.getByRole('button', { name: /show help/i }));
 
     expect(await screen.findByText('14.1 Straight Pool Help')).toBeInTheDocument();
     expect(

--- a/src/components/GameScoring/index.tsx
+++ b/src/components/GameScoring/index.tsx
@@ -672,109 +672,150 @@ const GameScoring: React.FC<GameScoringProps> = ({
         ))}
       </div>
 
-      <div className="flex justify-center mt-4">
-        <div
-          className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-sm shadow-sm dark:border-blue-800 dark:bg-blue-950/60"
-          data-testid="bot-indicator"
-          aria-label={`Balls on Table: ${ballsOnTable}`}
-          title="BOT = Balls on Table"
+      {/* Active-player action zone: end-of-inning actions + BOT context */}
+      <div className="mt-4 rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div className="mb-3 flex items-center justify-end gap-2 text-sm">
+          <span
+            className="text-gray-600 dark:text-gray-400"
+            data-testid="bot-indicator"
+            aria-label={`Balls on Table: ${ballsOnTable}`}
+            title="BOT = Balls on Table"
+          >
+            Balls on Table:{' '}
+            <span className="font-mono font-bold text-gray-900 dark:text-white">
+              {ballsOnTable}
+            </span>
+          </span>
+        </div>
+
+        <div className="space-y-2">
+          {/* Primary end-of-inning action */}
+          <button
+            type="button"
+            onClick={() => handleActionClick('miss')}
+            className="w-full rounded-lg bg-blue-600 hover:bg-blue-700 text-white px-3 py-3 text-sm font-semibold shadow-sm transition-colors"
+          >
+            Miss
+          </button>
+
+          {/* Qualifiers / alternative end-of-inning markers */}
+          <div className="grid grid-cols-3 gap-2">
+            <button
+              type="button"
+              onClick={() => handleActionClick('safety')}
+              className="rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-800 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-100 px-3 py-2.5 text-sm font-medium transition-colors"
+            >
+              Safety
+            </button>
+            <button
+              type="button"
+              onClick={() => handleActionClick('foul')}
+              className="rounded-lg bg-gray-100 hover:bg-red-50 text-gray-800 hover:text-red-700 dark:bg-gray-700 dark:hover:bg-red-900/40 dark:text-gray-100 dark:hover:text-red-200 px-3 py-2.5 text-sm font-medium transition-colors"
+            >
+              Foul
+            </button>
+            <button
+              type="button"
+              onClick={() => handleActionClick('newrack')}
+              className="rounded-lg bg-emerald-50 hover:bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:hover:bg-emerald-900/60 dark:text-emerald-200 px-3 py-2.5 text-sm font-medium transition-colors flex items-center justify-center gap-1"
+            >
+              <span aria-hidden="true">+</span>Rack
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Utility row + timers */}
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => setShowInningsModal(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 px-3 py-1.5 text-xs font-medium transition-colors"
+          title="View game innings"
         >
-          <span className="font-medium uppercase tracking-wide text-blue-700 dark:text-blue-200">
-            BOT
-          </span>
-          <span className="text-xs text-blue-600 dark:text-blue-300">Balls on Table</span>
-          <span className="rounded-full bg-white px-2.5 py-0.5 text-base font-bold text-blue-700 shadow-sm dark:bg-blue-900 dark:text-blue-100">
-            {ballsOnTable}
-          </span>
-        </div>
-      </div>
-
-      {/* Action buttons moved below player cards */}
-      <div className="flex justify-center items-center mt-4">
-        <div className="grid w-full max-w-xl grid-cols-2 gap-3 sm:grid-cols-4">
-          <button
-            onClick={() => setShowInningsModal(true)}
-            className="min-h-12 rounded bg-blue-600 px-3 py-3 text-sm font-medium text-white hover:bg-blue-700 flex items-center justify-center gap-2 shadow-sm"
-            title="View game innings"
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-              />
-            </svg>
-            Innings
-          </button>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+            />
+          </svg>
+          Innings
+        </button>
 
-          <button
-            onClick={handleUndoLastAction}
-            disabled={!isUndoEnabled}
-            className={`min-h-12 rounded px-3 py-3 flex items-center justify-center gap-2 text-sm font-medium shadow-sm ${
-              isUndoEnabled
-                ? 'bg-yellow-600 text-white hover:bg-yellow-700'
-                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-            }`}
-            title="Undo last action"
+        <button
+          type="button"
+          onClick={handleUndoLastAction}
+          disabled={!isUndoEnabled}
+          className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+            isUndoEnabled
+              ? 'bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200'
+              : 'bg-gray-50 text-gray-400 cursor-not-allowed dark:bg-gray-800 dark:text-gray-600'
+          }`}
+          title="Undo last action"
+          aria-label="Undo last action"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
-              />
-            </svg>
-            Undo
-          </button>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+            />
+          </svg>
+          Undo
+        </button>
 
-          <button
-            onClick={() => setShowEndGameModal(true)}
-            className="min-h-12 rounded bg-blue-600 px-3 py-3 text-sm font-medium text-white hover:bg-blue-700 flex items-center justify-center gap-2 shadow-sm"
+        <button
+          type="button"
+          onClick={() => setShowEndGameModal(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 px-3 py-1.5 text-xs font-medium transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-3.5 w-3.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0V9a8.002 8.002 0 0115.356 2M20 20v-5h-.581m-15.356-2A8.001 8.001 0 0019.419 15m0 0V15a8.002 8.002 0 00-15.356-2"
-              />
-            </svg>
-            New Game
-          </button>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+          End Game
+        </button>
 
-          <button
-            onClick={() => setShowHelpModal(true)}
-            className="min-h-12 rounded bg-slate-600 px-3 py-3 text-sm font-medium text-white hover:bg-slate-700 flex items-center justify-center gap-2 shadow-sm"
-            title="Show straight pool help"
-          >
-            <span className="text-base font-bold leading-none">?</span>
-            Help
-          </button>
-        </div>
-      </div>
+        <button
+          type="button"
+          onClick={() => setShowHelpModal(true)}
+          className="inline-flex items-center justify-center rounded-md bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 w-7 h-7 text-xs font-bold transition-colors"
+          title="Show straight pool help"
+          aria-label="Show help"
+        >
+          ?
+        </button>
 
-      {/* Timers at bottom */}
-      <div className="flex justify-center items-center gap-2 mt-4">
+        <span
+          className="mx-1 hidden h-5 w-px bg-gray-300 dark:bg-gray-600 sm:inline-block"
+          aria-hidden="true"
+        />
+
         <MatchTimer
           startTime={matchStartTime}
           endTime={matchEndTime}

--- a/src/components/GameSetup.tsx
+++ b/src/components/GameSetup.tsx
@@ -88,106 +88,99 @@ const GameSetup: React.FC<GameSetupProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 p-4">
-      <div className="max-w-md mx-auto pt-8">
-        {/* Header */}
-        <div className="text-center mb-6">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
-            New Game
-          </h1>
-          <p className="text-sm font-medium text-blue-700 dark:text-blue-300">
-            14.1 Straight Pool scorer
-          </p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Tap a player to select who breaks
-          </p>
+    <div className="max-w-md mx-auto">
+      {/* Header */}
+      <div className="text-center mb-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">
+          14.1 Straight Pool scorer
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900 dark:text-white">
+          New Game
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
+          Tap a player to select who breaks
+        </p>
+      </div>
+
+      {/* Error Message */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-xl mb-4 text-sm">
+          {error}
         </div>
+      )}
 
-        {/* Error Message */}
-        {error && (
-          <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-xl mb-4 text-sm">
-            {error}
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <PlayerCard
+          playerNumber={1}
+          playerName={player1}
+          targetScore={player1TargetScore}
+          onPlayerNameChange={setPlayer1}
+          onTargetScoreChange={setPlayer1TargetScore}
+          colorScheme="blue"
+          isBreaking={breakingPlayerId === 0}
+          onSelectBreaking={() => setBreakingPlayerId(0)}
+        />
+
+        <PlayerCard
+          playerNumber={2}
+          playerName={player2}
+          targetScore={player2TargetScore}
+          onPlayerNameChange={setPlayer2}
+          onTargetScoreChange={setPlayer2TargetScore}
+          colorScheme="green"
+          isBreaking={breakingPlayerId === 1}
+          onSelectBreaking={() => setBreakingPlayerId(1)}
+        />
+
+        <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-md border border-gray-100 dark:border-gray-700">
+          <div className="mb-3">
+            <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
+              Shot Clock
+            </h2>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Choose the per-turn timer for this match.
+            </p>
           </div>
-        )}
 
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <PlayerCard
-            playerNumber={1}
-            playerName={player1}
-            targetScore={player1TargetScore}
-            onPlayerNameChange={setPlayer1}
-            onTargetScoreChange={setPlayer1TargetScore}
-            colorScheme="blue"
-            isBreaking={breakingPlayerId === 0}
-            onSelectBreaking={() => setBreakingPlayerId(0)}
-          />
-
-          <PlayerCard
-            playerNumber={2}
-            playerName={player2}
-            targetScore={player2TargetScore}
-            onPlayerNameChange={setPlayer2}
-            onTargetScoreChange={setPlayer2TargetScore}
-            colorScheme="green"
-            isBreaking={breakingPlayerId === 1}
-            onSelectBreaking={() => setBreakingPlayerId(1)}
-          />
-
-          <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-md border border-gray-100 dark:border-gray-700">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
-                  Shot Clock
-                </h2>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  Choose the per-turn timer for this match.
-                </p>
-              </div>
-              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
-                {shotClockSeconds === null ? 'Off' : `${shotClockSeconds}s`}
-              </span>
-            </div>
-
-            <div className="grid grid-cols-4 gap-2 mt-3">
+          <div className="grid grid-cols-4 gap-2">
+            <button
+              type="button"
+              onClick={() => setShotClockSeconds(null)}
+              aria-pressed={shotClockSeconds === null}
+              className={`rounded-xl px-3 py-2 text-sm font-medium transition-colors ${
+                shotClockSeconds === null
+                  ? 'bg-blue-600 text-white shadow-sm'
+                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
+              }`}
+            >
+              Off
+            </button>
+            {SHOT_CLOCK_PRESET_SECONDS.map((preset) => (
               <button
+                key={preset}
                 type="button"
-                onClick={() => setShotClockSeconds(null)}
-                aria-pressed={shotClockSeconds === null}
+                onClick={() => setShotClockSeconds(preset)}
+                aria-pressed={shotClockSeconds === preset}
                 className={`rounded-xl px-3 py-2 text-sm font-medium transition-colors ${
-                  shotClockSeconds === null
-                    ? 'bg-slate-700 text-white'
-                    : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600'
+                  shotClockSeconds === preset
+                    ? 'bg-blue-600 text-white shadow-sm'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
                 }`}
               >
-                Off
+                {preset}s
               </button>
-              {SHOT_CLOCK_PRESET_SECONDS.map((preset) => (
-                <button
-                  key={preset}
-                  type="button"
-                  onClick={() => setShotClockSeconds(preset)}
-                  aria-pressed={shotClockSeconds === preset}
-                  className={`rounded-xl px-3 py-2 text-sm font-medium transition-colors ${
-                    shotClockSeconds === preset
-                      ? 'bg-orange-600 text-white'
-                      : 'bg-orange-50 text-orange-700 hover:bg-orange-100 dark:bg-orange-900/40 dark:text-orange-200 dark:hover:bg-orange-900/70'
-                  }`}
-                >
-                  {preset}s
-                </button>
-              ))}
-            </div>
-          </section>
+            ))}
+          </div>
+        </section>
 
-          {/* Start Game Button */}
-          <button
-            type="submit"
-            className="w-full bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white py-4 px-8 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-[1.02] transition-all duration-200 mt-4"
-          >
-            Start Game
-          </button>
-        </form>
-      </div>
+        {/* Start Game Button */}
+        <button
+          type="submit"
+          className="w-full bg-gradient-to-r from-blue-600 to-blue-700 dark:from-blue-700 dark:to-blue-800 text-white py-4 px-8 rounded-xl font-semibold text-lg shadow-lg hover:shadow-xl transform hover:scale-[1.02] transition-all duration-200 mt-4"
+        >
+          Start Game
+        </button>
+      </form>
     </div>
   );
 };

--- a/src/components/GameStatistics.tsx
+++ b/src/components/GameStatistics.tsx
@@ -2,32 +2,14 @@ import React, { useState, useEffect, useMemo } from 'react';
 
 import { useError } from '../context/ErrorContext';
 import { type GameStatisticsProps, type GameData, type Player } from '../types/game';
+import { computeMatchLength } from '../utils/computeMatchLength';
 import { copyWithFeedback } from '../utils/copyToClipboard';
+import { formatGameDateLong } from '../utils/formatGameDate';
 
 import { InningsModal } from './GameStatistics/components/InningsModal';
 import { StatDescriptionsModal } from './GameStatistics/components/StatDescriptionsModal';
 import { GameSummaryPanel } from './shared/GameSummaryPanel';
 import { calculatePlayerStats } from './shared/stats';
-
-/**
- * Compute match length from the game's actual start/end timestamps when present,
- * with a graceful fallback for older records that only carry `date`.
- */
-const computeMatchLength = (game: GameData): string => {
-  const startSrc = game.startTime ?? game.date;
-  const endSrc = game.endTime ?? (game.completed ? null : new Date());
-  if (!startSrc || !endSrc) return '—';
-  const start = new Date(startSrc);
-  const end = new Date(endSrc);
-  const diffMs = Math.max(0, end.getTime() - start.getTime());
-  if (diffMs < 60 * 1000) {
-    const seconds = Math.max(1, Math.floor(diffMs / 1000));
-    return `${seconds}s`;
-  }
-  const hours = Math.floor(diffMs / (1000 * 60 * 60));
-  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
-};
 
 /**
  * Derive a contextual headline from game state. Prefers the explicit winner,
@@ -171,18 +153,6 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
   const formatGameResultsForEmail = useMemo(() => {
     if (!gameData) return '';
 
-    const gameDate = new Date(gameData.date);
-    const formattedDate = gameDate.toLocaleDateString('en-US', {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-    });
-    const formattedTime = gameDate.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
-
     // Calculate match length using actual start/end timestamps when available.
     const matchLength = computeMatchLength(gameData);
 
@@ -193,7 +163,7 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
       return 0;
     });
 
-    let emailText = `${formattedDate} at ${formattedTime}\n`;
+    let emailText = `${formatGameDateLong(gameData.date)}\n`;
     emailText += `Length: ${matchLength}\n\n`;
 
     // Add player results

--- a/src/components/GameStatistics.tsx
+++ b/src/components/GameStatistics.tsx
@@ -1,13 +1,68 @@
 import React, { useState, useEffect, useMemo } from 'react';
 
 import { useError } from '../context/ErrorContext';
-import { type GameStatisticsProps, type GameData } from '../types/game';
+import { type GameStatisticsProps, type GameData, type Player } from '../types/game';
 import { copyWithFeedback } from '../utils/copyToClipboard';
 
 import { InningsModal } from './GameStatistics/components/InningsModal';
 import { StatDescriptionsModal } from './GameStatistics/components/StatDescriptionsModal';
 import { GameSummaryPanel } from './shared/GameSummaryPanel';
 import { calculatePlayerStats } from './shared/stats';
+
+/**
+ * Compute match length from the game's actual start/end timestamps when present,
+ * with a graceful fallback for older records that only carry `date`.
+ */
+const computeMatchLength = (game: GameData): string => {
+  const startSrc = game.startTime ?? game.date;
+  const endSrc = game.endTime ?? (game.completed ? null : new Date());
+  if (!startSrc || !endSrc) return '—';
+  const start = new Date(startSrc);
+  const end = new Date(endSrc);
+  const diffMs = Math.max(0, end.getTime() - start.getTime());
+  if (diffMs < 60 * 1000) {
+    const seconds = Math.max(1, Math.floor(diffMs / 1000));
+    return `${seconds}s`;
+  }
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+};
+
+/**
+ * Derive a contextual headline from game state. Prefers the explicit winner,
+ * falls back to the score leader for stopped games.
+ */
+const deriveHeadline = (game: GameData): { primary: string; secondary?: string } => {
+  if (!game.completed) {
+    return { primary: 'Game in progress' };
+  }
+  const players = game.players;
+  if (game.winner_id !== null && game.winner_id !== undefined) {
+    const winner = players.find((p) => p.id === game.winner_id);
+    const loser = players.find((p) => p.id !== game.winner_id);
+    if (winner && loser) {
+      return {
+        primary: `${winner.name} wins`,
+        secondary: `${winner.score}–${loser.score}`,
+      };
+    }
+  }
+  // No declared winner (manual end). Show the score and call it stopped.
+  const sorted = [...players].sort((a: Player, b: Player) => b.score - a.score);
+  const top = sorted[0];
+  const bottom = sorted[1];
+  if (top && bottom) {
+    if (top.score === bottom.score) {
+      return { primary: 'Game tied', secondary: `${top.score}–${bottom.score}` };
+    }
+    return {
+      primary: `${top.name} ahead`,
+      secondary: `${top.score}–${bottom.score}`,
+    };
+  }
+  return { primary: 'Game ended' };
+};
 
 const GameStatistics: React.FC<GameStatisticsProps> = ({
   gameId,
@@ -128,13 +183,8 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
       hour12: true,
     });
 
-    // Calculate match length
-    const startTime = new Date(gameData.date);
-    const endTime = gameData.completed ? new Date(gameData.date) : new Date();
-    const diffMs = endTime.getTime() - startTime.getTime();
-    const hours = Math.floor(diffMs / (1000 * 60 * 60));
-    const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-    const matchLength = `${hours}h ${minutes}m`;
+    // Calculate match length using actual start/end timestamps when available.
+    const matchLength = computeMatchLength(gameData);
 
     // Sort players to show winner first
     const sortedPlayers = [...gameData.players].sort((a, b) => {
@@ -215,26 +265,27 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
     );
   }
 
-  // Calculate match length
-  const startTime = new Date(gameData.date);
-  const endTime = gameData.completed ? new Date(gameData.date) : new Date();
-  const diffMs = endTime.getTime() - startTime.getTime();
-  const hours = Math.floor(diffMs / (1000 * 60 * 60));
-  const minutes = Math.ceil((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-  const matchLength = `${hours}h ${minutes}m`;
+  // Calculate match length using actual start/end timestamps when available.
+  const matchLength = computeMatchLength(gameData);
+
+  const headline = deriveHeadline(gameData);
 
   return (
     <div className="max-w-4xl mx-auto">
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-2xl font-bold dark:text-white">Game Statistics</h2>
-        {user && (
-          <button
-            onClick={viewHistory}
-            className="px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-800"
-          >
-            View History
-          </button>
-        )}
+      <div className="mb-5 text-center sm:text-left">
+        <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          Game Result
+        </p>
+        <div className="mt-1 flex flex-wrap items-baseline justify-center gap-x-3 gap-y-1 sm:justify-start">
+          <h2 className="text-2xl sm:text-3xl font-bold dark:text-white">
+            {headline.primary}
+          </h2>
+          {headline.secondary && (
+            <span className="font-mono text-xl text-gray-500 dark:text-gray-400">
+              {headline.secondary}
+            </span>
+          )}
+        </div>
       </div>
 
       <GameSummaryPanel
@@ -251,6 +302,39 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
         onShowDescriptions={() => setShowDescriptionsModal(true)}
         copySuccess={copySuccess}
       />
+
+      {/* Primary navigation actions for the post-game flow */}
+      <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+        <button
+          onClick={startNewGame}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white px-5 py-2.5 text-sm font-semibold shadow-sm transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          Start New Game
+        </button>
+        {user && (
+          <button
+            onClick={viewHistory}
+            className="inline-flex items-center gap-2 rounded-lg bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200 px-4 py-2.5 text-sm font-medium transition-colors"
+          >
+            View History
+          </button>
+        )}
+      </div>
 
       {/* Innings Modal */}
       {gameData && (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -115,28 +115,26 @@ export const Header: FC<HeaderProps> = ({
               </div>
             </div>
           ) : (
-            <div className="flex items-center space-x-2">
-              <div className="relative">
-                <button
-                  className="bg-gray-400 dark:bg-gray-600 hover:bg-gray-500 dark:hover:bg-gray-500 p-2 rounded-full text-gray-300 dark:text-gray-400 hover:text-gray-200 transition-colors"
-                  onClick={onAuthClick}
-                  aria-label="Open authentication modal"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
+            <button
+              className="inline-flex items-center gap-1.5 bg-blue-700 hover:bg-blue-600 dark:bg-blue-800 dark:hover:bg-blue-700 px-3 py-1.5 rounded-md text-sm font-medium text-white transition-colors"
+              onClick={onAuthClick}
+              aria-label="Sign in"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M3 3a1 1 0 011 1v12a1 1 0 11-2 0V4a1 1 0 011-1zm7.707 3.293a1 1 0 010 1.414L9.414 9H17a1 1 0 110 2H9.414l1.293 1.293a1 1 0 01-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <span>Sign in</span>
+            </button>
           )}
         </div>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -10,8 +10,9 @@ interface NavigationProps {
 }
 
 export const Navigation: FC<NavigationProps> = ({ gameState, user, onNavigate }) => {
-  // Only show navigation tabs when not in an active game
-  if (gameState === 'scoring') {
+  // Hide nav during active scoring, and when signed out (only "New Game" would show — redundant
+  // with the page-level Start New Game CTAs and the page itself).
+  if (gameState === 'scoring' || !user) {
     return null;
   }
 

--- a/src/components/PlayerCard.tsx
+++ b/src/components/PlayerCard.tsx
@@ -39,12 +39,13 @@ const PlayerCard: React.FC<PlayerCardProps> = ({
       className={`bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-md border-2 transition-all duration-200 cursor-pointer ${
         isBreaking
           ? `${color.borderActive} ${color.bgLight}`
-          : 'border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600'
+          : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
       }`}
       role="button"
       aria-pressed={isBreaking}
       aria-label={`Player ${playerNumber}${isBreaking ? ' (breaking)' : ''} - tap to select as breaking player`}
     >
+      {/* Top row: badge + name + breaking pill */}
       <div className="flex items-center gap-3">
         {/* Player badge */}
         <div
@@ -62,15 +63,35 @@ const PlayerCard: React.FC<PlayerCardProps> = ({
           type="text"
           value={playerName}
           onChange={(e) => onPlayerNameChange(e.target.value)}
-          className="flex-1 text-lg font-semibold bg-transparent border-none outline-none placeholder-gray-300 dark:placeholder-gray-600 text-gray-900 dark:text-white min-w-0"
-          placeholder={`Player ${playerNumber}`}
+          onClick={(e) => e.stopPropagation()}
+          className="flex-1 text-lg font-semibold bg-transparent border-0 border-b-2 border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 focus:border-blue-500 dark:focus:border-blue-400 outline-none placeholder-gray-400 dark:placeholder-gray-500 text-gray-900 dark:text-white min-w-0 px-1 py-0.5 transition-colors"
+          placeholder={`Enter Player ${playerNumber} name`}
           aria-label={`Player ${playerNumber} name`}
           required
         />
 
-        {/* Target score input */}
-        <div className="flex items-center gap-1 flex-shrink-0">
+        {/* Breaking pill (right side) */}
+        {isBreaking && (
+          <span
+            className={`inline-flex items-center gap-1 ${color.badge} ${color.text} text-xs font-semibold px-2.5 py-1 rounded-full flex-shrink-0`}
+          >
+            <span>🎱</span>
+            <span>Breaking</span>
+          </span>
+        )}
+      </div>
+
+      {/* Bottom row: target score input + hint when not breaking */}
+      <div className="flex items-center justify-between gap-3 mt-3">
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor={`player-${playerNumber}-target`}
+            className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"
+          >
+            Target
+          </label>
           <input
+            id={`player-${playerNumber}-target`}
             type="text"
             inputMode="numeric"
             pattern="[0-9]*"
@@ -79,21 +100,21 @@ const PlayerCard: React.FC<PlayerCardProps> = ({
               const val = e.target.value.replace(/\D/g, '');
               onTargetScoreChange(val ? Number(val) : 0);
             }}
-            className="w-16 text-lg font-bold bg-gray-100 dark:bg-gray-700 rounded-lg px-2 py-1 text-center text-gray-900 dark:text-white"
+            onClick={(e) => e.stopPropagation()}
+            className="w-16 text-base font-bold bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500 focus:border-blue-500 dark:focus:border-blue-400 focus:ring-2 focus:ring-blue-500/20 rounded-md px-2 py-1 text-center text-gray-900 dark:text-white outline-none transition-colors"
             aria-label={`Player ${playerNumber} target score`}
             required
           />
-          <span className="text-sm text-gray-400 dark:text-gray-500">pts</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">pts</span>
         </div>
-      </div>
 
-      {/* Breaking indicator */}
-      {isBreaking && (
-        <div className={`mt-2 text-xs font-medium ${color.text} flex items-center gap-1`}>
-          <span>🎱</span>
-          <span>Breaking</span>
-        </div>
-      )}
+        {/* Hint when not selected as breaker */}
+        {!isBreaking && (
+          <span className="text-xs text-gray-400 dark:text-gray-500 italic">
+            Tap card to set as breaker
+          </span>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/PlayerScoreCard.test.tsx
+++ b/src/components/PlayerScoreCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import { createMockPlayer } from '../testing/factories';
 
@@ -8,28 +8,8 @@ import PlayerScoreCard from './PlayerScoreCard';
 
 // No longer need helper function - use semantic queries instead
 
-// Mock the ScoreButton component to simplify testing
-vi.mock('./ScoreButton', () => ({
-  default: function mockScoreButton(props: any) {
-    // Handle both string and non-string labels safely
-    let labelStr: string;
-    if (typeof props.label === 'string') {
-      labelStr = props.label;
-    } else if (React.isValidElement(props.label)) {
-      // For complex React elements like the Rack button, extract text content
-      labelStr = 'rack'; // Default to 'rack' for the complex button
-    } else {
-      labelStr = String(props.label);
-    }
-    const testId = `score-button-${labelStr.toLowerCase().replace(/\s+/g, '-')}`;
-
-    return (
-      <button onClick={() => props.onClick(props.value)} data-testid={testId}>
-        {props.label}
-      </button>
-    );
-  },
-}));
+// PlayerScoreCard no longer renders action buttons (those moved to GameScoring's
+// active-player action zone), so no ScoreButton mock is needed here.
 
 describe('PlayerScoreCard Component', () => {
   // Sample player data for testing
@@ -125,7 +105,7 @@ describe('PlayerScoreCard Component', () => {
     );
   });
 
-  test('shows active styling when isActive is true', () => {
+  test('marks the active card with aria-current', () => {
     render(
       <PlayerScoreCard
         player={mockPlayer}
@@ -138,33 +118,10 @@ describe('PlayerScoreCard Component', () => {
       />,
     );
 
-    // Score buttons should be visible when active (using the mock test IDs)
-    expect(screen.getByTestId('score-button-miss')).toBeInTheDocument();
-    expect(screen.getByTestId('score-button-foul')).toBeInTheDocument();
-    expect(screen.getByTestId('score-button-safety')).toBeInTheDocument();
-    expect(screen.getByTestId('score-button-rack')).toBeInTheDocument();
+    expect(screen.getByTestId('player-card')).toHaveAttribute('aria-current', 'true');
   });
 
-  test('does not show score buttons when not active', () => {
-    render(
-      <PlayerScoreCard
-        player={mockPlayer}
-        isActive={false}
-        onAddScore={mockHandlers.onAddScore}
-        onAddFoul={mockHandlers.onAddFoul}
-        onAddSafety={mockHandlers.onAddSafety}
-        onAddMiss={mockHandlers.onAddMiss}
-        targetScore={75}
-      />,
-    );
-
-    // Score buttons should not be visible when inactive
-    expect(screen.queryByTestId('score-button-miss')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('score-button-foul-(-1)')).not.toBeInTheDocument();
-    // etc.
-  });
-
-  test('calls the appropriate functions when buttons are clicked', () => {
+  test('does not render in-card action buttons (they live in GameScoring now)', () => {
     render(
       <PlayerScoreCard
         player={mockPlayer}
@@ -173,26 +130,16 @@ describe('PlayerScoreCard Component', () => {
         onAddFoul={mockHandlers.onAddFoul}
         onAddSafety={mockHandlers.onAddSafety}
         onAddMiss={mockHandlers.onAddMiss}
-        onShowHistory={mockHandlers.onShowHistory}
         targetScore={75}
       />,
     );
 
-    // Click on Miss button - the component calls onAddMiss() without parameters
-    fireEvent.click(screen.getByTestId('score-button-miss'));
-    expect(mockHandlers.onAddMiss).toHaveBeenCalledTimes(1);
-
-    // Click on Foul button - the component calls onAddFoul() without parameters
-    fireEvent.click(screen.getByTestId('score-button-foul'));
-    expect(mockHandlers.onAddFoul).toHaveBeenCalledTimes(1);
-
-    // Click on Safety button - the component calls onAddSafety() without parameters
-    fireEvent.click(screen.getByTestId('score-button-safety'));
-    expect(mockHandlers.onAddSafety).toHaveBeenCalledTimes(1);
-
-    // Click on Rack button - the component calls onAddScore(1)
-    fireEvent.click(screen.getByTestId('score-button-rack'));
-    expect(mockHandlers.onAddScore).toHaveBeenCalledWith(1);
+    // PlayerScoreCard is now data-only; the action buttons live in
+    // GameScoring's active-player action zone.
+    expect(screen.queryByRole('button', { name: /^Miss$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Foul$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Safety$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rack/i })).not.toBeInTheDocument();
   });
 
   test('handles zero innings case correctly for BPI calculation', () => {

--- a/src/components/PlayerScoreCard.tsx
+++ b/src/components/PlayerScoreCard.tsx
@@ -2,8 +2,6 @@ import React, { useMemo, memo } from 'react';
 
 import { type Player } from '../types/game';
 
-import ScoreButton from './ScoreButton';
-
 interface PlayerScoreCardProps {
   player: Player;
   isActive: boolean;
@@ -22,10 +20,10 @@ interface PlayerScoreCardProps {
 const PlayerScoreCard: React.FC<PlayerScoreCardProps> = ({
   player,
   isActive,
-  onAddScore,
-  onAddFoul,
-  onAddSafety,
-  onAddMiss,
+  onAddScore: _onAddScore,
+  onAddFoul: _onAddFoul,
+  onAddSafety: _onAddSafety,
+  onAddMiss: _onAddMiss,
   onShowHistory: _onShowHistory,
   targetScore,
   onRegularShot: _onRegularShot,
@@ -44,14 +42,19 @@ const PlayerScoreCard: React.FC<PlayerScoreCardProps> = ({
   return (
     <div
       data-testid="player-card"
+      aria-current={isActive ? 'true' : undefined}
       className={`rounded-lg p-3 mb-2 transition-all duration-300 ${
         isActive
-          ? 'bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900 dark:to-blue-800 border-2 border-blue-500 shadow-lg shadow-blue-200 dark:shadow-blue-900/50 scale-[1.02]'
-          : 'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 opacity-80 shadow-md'
+          ? 'bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/60 dark:to-blue-800/60 border-2 border-blue-500 shadow-lg shadow-blue-200/50 dark:shadow-blue-900/30'
+          : 'bg-white dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 shadow-sm'
       }`}
     >
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-2xl font-extrabold dark:text-white">
+        <h3
+          className={`text-2xl dark:text-white ${
+            isActive ? 'font-extrabold' : 'font-semibold text-gray-700 dark:text-gray-300'
+          }`}
+        >
           {player.name}
           {player.score >= targetScore && (
             <span className="ml-1 text-yellow-500">🏆</span>
@@ -61,19 +64,19 @@ const PlayerScoreCard: React.FC<PlayerScoreCardProps> = ({
           {isActive === true && !needsReBreak && isInitialBreak && (
             <button
               onClick={onBreakClick}
-              className="bg-red-500 hover:bg-red-600 text-white px-2 py-0.5 rounded text-xs transition-colors cursor-pointer"
+              className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-0.5 rounded text-xs transition-colors cursor-pointer"
               title="Click to change breaking player"
             >
               Break
             </button>
           )}
           {needsReBreak && (
-            <span className="bg-red-500 text-white px-3 py-1 rounded-full text-sm font-medium">
+            <span className="bg-amber-500 text-white px-3 py-1 rounded-full text-sm font-medium">
               Re-Break
             </span>
           )}
           {player.consecutiveFouls >= 2 && (
-            <span className="bg-orange-500 text-white px-2 py-0.5 rounded text-xs">
+            <span className="bg-red-500 text-white px-2 py-0.5 rounded text-xs">
               2 Fouls
             </span>
           )}
@@ -89,7 +92,9 @@ const PlayerScoreCard: React.FC<PlayerScoreCardProps> = ({
                 ? 'text-green-600 dark:text-green-500'
                 : player.score < 0
                   ? 'text-red-600 dark:text-red-500'
-                  : 'text-blue-700 dark:text-blue-400'
+                  : isActive
+                    ? 'text-blue-700 dark:text-blue-300'
+                    : 'text-gray-500 dark:text-gray-400'
             }`}
           >
             {player.score < 0 && '-'}
@@ -139,57 +144,7 @@ const PlayerScoreCard: React.FC<PlayerScoreCardProps> = ({
         />
       </div>
 
-      {isActive && (
-        <div className="mt-3 space-y-3">
-          <ScoreButton
-            label="Miss"
-            value={0}
-            onClick={() => onAddMiss()}
-            className="bg-gray-500 hover:bg-gray-600 hover:shadow-lg hover:scale-105 transition-all duration-150 border border-gray-400 dark:border-gray-500 w-full"
-          />
-
-          <div className="grid grid-cols-3 gap-3">
-            <ScoreButton
-              label="Safety"
-              value={0}
-              onClick={() => onAddSafety()}
-              className="bg-yellow-600 hover:bg-yellow-700 hover:shadow-lg hover:scale-105 transition-all duration-150"
-            />
-
-            <ScoreButton
-              label="Foul"
-              value={-1}
-              onClick={() => onAddFoul()}
-              className="bg-red-600 hover:bg-red-700 hover:shadow-lg hover:scale-105 transition-all duration-150"
-            />
-
-            <ScoreButton
-              label={
-                <div className="flex items-center justify-center space-x-1">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="h-5 w-5"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
-                  >
-                    <path
-                      fillRule="evenodd"
-                      d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z"
-                      clipRule="evenodd"
-                    />
-                  </svg>
-                  <span>Rack</span>
-                </div>
-              }
-              value={1}
-              onClick={() => onAddScore(1)}
-              className="bg-green-600 hover:bg-green-700 hover:shadow-lg hover:scale-105 transition-all duration-150 whitespace-nowrap"
-            />
-          </div>
-        </div>
-      )}
-
-      <div className="mt-2 grid grid-cols-3 gap-1 text-center text-sm text-gray-500 dark:text-gray-400">
+      <div className="mt-3 grid grid-cols-3 gap-1 text-center text-sm text-gray-500 dark:text-gray-400">
         <div>
           <span className="font-bold dark:text-gray-300">{player.safeties}</span>{' '}
           <span className="font-medium">Safeties</span>

--- a/src/components/TurnTimer.tsx
+++ b/src/components/TurnTimer.tsx
@@ -74,18 +74,29 @@ export const TurnTimer: React.FC<TurnTimerProps> = memo(
       `${minutes.toString().padStart(2, '0')}:` +
       `${seconds.toString().padStart(2, '0')}`;
     const isOverLimit = elapsedSeconds >= shotClockSeconds;
+    const isApproaching =
+      !isOverLimit && elapsedSeconds >= Math.floor(shotClockSeconds * 0.75);
+    // Three states: neutral (in budget), approaching (>=75%), over.
     const containerClasses = isOverLimit
       ? 'bg-red-100 dark:bg-red-900'
-      : 'bg-orange-100 dark:bg-orange-900';
+      : isApproaching
+        ? 'bg-amber-100 dark:bg-amber-900/60'
+        : 'bg-gray-100 dark:bg-gray-700';
     const iconClasses = isOverLimit
       ? 'text-red-600 dark:text-red-300'
-      : 'text-orange-600 dark:text-orange-400';
+      : isApproaching
+        ? 'text-amber-600 dark:text-amber-300'
+        : 'text-gray-500 dark:text-gray-300';
     const timeClasses = isOverLimit
       ? 'text-red-800 dark:text-red-100'
-      : 'text-orange-800 dark:text-orange-200';
+      : isApproaching
+        ? 'text-amber-800 dark:text-amber-100'
+        : 'text-gray-800 dark:text-gray-200';
     const badgeClasses = isOverLimit
       ? 'bg-red-200 text-red-800 dark:bg-red-800 dark:text-red-100'
-      : 'bg-orange-200 text-orange-800 dark:bg-orange-800 dark:text-orange-100';
+      : isApproaching
+        ? 'bg-amber-200 text-amber-800 dark:bg-amber-800 dark:text-amber-100'
+        : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200';
 
     return (
       <div

--- a/src/components/auth/Auth.tsx
+++ b/src/components/auth/Auth.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { type SupabaseClient } from '@supabase/supabase-js';
 
@@ -6,74 +6,86 @@ import Login from './Login';
 import ResetPassword from './ResetPassword';
 import SignUp from './SignUp';
 
-type AuthTab = 'login' | 'signup' | 'reset-password';
+export type AuthTab = 'login' | 'signup' | 'reset-password';
 
 interface AuthProps {
   supabase: SupabaseClient;
+  /**
+   * Active tab is owned by the parent (AuthModal) so it can also drive
+   * the per-tab modal title and conditionally hide the benefits panel
+   * on Reset Password.
+   */
+  activeTab: AuthTab;
+  onTabChange: (tab: AuthTab) => void;
   onAuthSuccess?: () => void;
 }
 
-const Auth: React.FC<AuthProps> = ({ supabase, onAuthSuccess }) => {
-  const [activeTab, setActiveTab] = useState<AuthTab>('login');
+interface TabDefinition {
+  id: AuthTab;
+  label: string;
+}
 
+/**
+ * Tab labels are kept short ("Reset" instead of "Reset Password") so all
+ * three tabs fit on one line at narrow modal widths. The Login form
+ * surfaces a "Forgot password?" link as the primary discovery path; the
+ * tab is here for users who already know what they need.
+ */
+const TABS: TabDefinition[] = [
+  { id: 'login', label: 'Login' },
+  { id: 'signup', label: 'Sign Up' },
+  { id: 'reset-password', label: 'Reset' },
+];
+
+const Auth: React.FC<AuthProps> = ({
+  supabase,
+  activeTab,
+  onTabChange,
+  onAuthSuccess,
+}) => {
   return (
-    <div className="max-w-md mx-auto bg-white dark:bg-gray-800 rounded-xl shadow-2xl overflow-hidden transform transition-all duration-300 ease-in-out">
+    <div className="overflow-hidden">
       {/* Tabs */}
-      <div className="flex bg-gray-50 dark:bg-gray-700/50 border-b dark:border-gray-600">
-        <button
-          className={`py-2.5 px-6 flex-1 text-center font-medium transition-all duration-200 relative ${
-            activeTab === 'login'
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-          }`}
-          onClick={() => setActiveTab('login')}
-        >
-          Login
-          {activeTab === 'login' && (
-            <div className="absolute bottom-0 left-0 w-full h-0.5 bg-blue-600 dark:bg-blue-400 transform scale-x-100 transition-transform duration-200" />
-          )}
-        </button>
-        <button
-          className={`py-2.5 px-6 flex-1 text-center font-medium transition-all duration-200 relative ${
-            activeTab === 'signup'
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-          }`}
-          onClick={() => setActiveTab('signup')}
-        >
-          Sign Up
-          {activeTab === 'signup' && (
-            <div className="absolute bottom-0 left-0 w-full h-0.5 bg-blue-600 dark:bg-blue-400 transform scale-x-100 transition-transform duration-200" />
-          )}
-        </button>
-        <button
-          className={`py-2.5 px-6 flex-1 text-center font-medium transition-all duration-200 relative ${
-            activeTab === 'reset-password'
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
-          }`}
-          onClick={() => setActiveTab('reset-password')}
-        >
-          Reset Password
-          {activeTab === 'reset-password' && (
-            <div className="absolute bottom-0 left-0 w-full h-0.5 bg-blue-600 dark:bg-blue-400 transform scale-x-100 transition-transform duration-200" />
-          )}
-        </button>
+      <div
+        className="flex bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-lg p-1 mb-4"
+        role="tablist"
+      >
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onTabChange(tab.id)}
+              className={`flex-1 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                isActive
+                  ? 'bg-white dark:bg-gray-800 text-blue-600 dark:text-blue-400 shadow-sm'
+                  : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
       </div>
 
       {/* Content */}
-      <div className="p-4 dark:text-white">
-        <div className="transform transition-all duration-300 ease-in-out">
-          {activeTab === 'login' && (
-            <Login supabase={supabase} onSuccess={onAuthSuccess} />
-          )}
-          {activeTab === 'signup' && (
-            <SignUp supabase={supabase} onSuccess={onAuthSuccess} />
-          )}
-          {activeTab === 'reset-password' && (
-            <ResetPassword supabase={supabase} onSuccess={onAuthSuccess} />
-          )}
-        </div>
+      <div>
+        {activeTab === 'login' && (
+          <Login
+            supabase={supabase}
+            onSuccess={onAuthSuccess}
+            onForgotPassword={() => onTabChange('reset-password')}
+          />
+        )}
+        {activeTab === 'signup' && (
+          <SignUp supabase={supabase} onSuccess={onAuthSuccess} />
+        )}
+        {activeTab === 'reset-password' && (
+          <ResetPassword supabase={supabase} onSuccess={onAuthSuccess} />
+        )}
       </div>
     </div>
   );

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -7,6 +7,12 @@ import { getAuthCallbackUrl } from '../../utils/authRedirect';
 interface LoginProps {
   supabase: SupabaseClient;
   onSuccess?: () => void;
+  /**
+   * Triggered by the "Forgot password?" link below the password field.
+   * Lets the parent (Auth) switch the active tab to Reset Password rather
+   * than requiring users to discover the third tab themselves.
+   */
+  onForgotPassword?: () => void;
 }
 
 const getErrorMessage = (error: unknown, fallback: string) => {
@@ -16,7 +22,7 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
-const Login: React.FC<LoginProps> = ({ supabase, onSuccess }) => {
+const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -95,12 +101,25 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess }) => {
         </div>
 
         <div>
-          <label
-            htmlFor="password"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-          >
-            Password
-          </label>
+          <div className="flex items-baseline justify-between mb-1">
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Password
+            </label>
+            {/* "Forgot password?" — primary discovery path for the reset
+                flow. Users look for it here before scanning the tab bar. */}
+            {onForgotPassword && (
+              <button
+                type="button"
+                onClick={onForgotPassword}
+                className="text-xs font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+              >
+                Forgot password?
+              </button>
+            )}
+          </div>
           <input
             id="password"
             type="password"

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { type SupabaseClient, type User } from '@supabase/supabase-js';
+
+import { formatGameDateTime } from '../../utils/formatGameDate';
 
 interface UserProfileProps {
   supabase: SupabaseClient;
@@ -15,6 +17,119 @@ const getErrorMessage = (error: unknown, fallback = 'An error occurred') => {
   return fallback;
 };
 
+const formatMemberSince = (raw: string | undefined): string => {
+  if (!raw) return '—';
+  const date = new Date(raw);
+  return date.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+};
+
+interface ProfileStats {
+  loading: boolean;
+  totalGames: number;
+  lastGameDate: string | null;
+}
+
+const useProfileStats = (
+  supabase: SupabaseClient,
+  userId: string | undefined,
+): ProfileStats => {
+  const [stats, setStats] = useState<ProfileStats>({
+    loading: true,
+    totalGames: 0,
+    lastGameDate: null,
+  });
+
+  useEffect(() => {
+    if (!userId) {
+      setStats({ loading: false, totalGames: 0, lastGameDate: null });
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      // One round-trip for both counters: order by date desc, then derive
+      // total = data.length and last = data[0]?.date. Cheap because each
+      // row only carries the date column. Acceptable while game volume per
+      // account stays small.
+      const { data, error } = await supabase
+        .from('games')
+        .select('date')
+        .eq('owner_id', userId)
+        .eq('deleted', false)
+        .order('date', { ascending: false });
+
+      if (cancelled) return;
+      if (error || !data) {
+        setStats({ loading: false, totalGames: 0, lastGameDate: null });
+        return;
+      }
+
+      setStats({
+        loading: false,
+        totalGames: data.length,
+        lastGameDate: data.length > 0 && data[0]?.date ? String(data[0].date) : null,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [supabase, userId]);
+
+  return stats;
+};
+
+const Field: React.FC<{ label: string; children: React.ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <div className="flex items-baseline justify-between gap-4 py-2">
+    <dt className="text-sm text-gray-500 dark:text-gray-400">{label}</dt>
+    <dd className="text-sm font-medium text-gray-900 dark:text-gray-100 text-right">
+      {children}
+    </dd>
+  </div>
+);
+
+const SectionCard: React.FC<{
+  heading: string;
+  children: React.ReactNode;
+}> = ({ heading, children }) => (
+  <section className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden">
+    <header className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
+      <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{heading}</h3>
+    </header>
+    <div className="p-4">{children}</div>
+  </section>
+);
+
+const SubmitSpinner: React.FC = () => (
+  <svg
+    className="animate-spin -ml-1 mr-2 h-4 w-4"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+  >
+    <circle
+      className="opacity-25"
+      cx="12"
+      cy="12"
+      r="10"
+      stroke="currentColor"
+      strokeWidth="4"
+    />
+    <path
+      className="opacity-75"
+      fill="currentColor"
+      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+    />
+  </svg>
+);
+
 const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -24,6 +139,12 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
   const [showSuccessAnimation, setShowSuccessAnimation] = useState(false);
+
+  const {
+    loading: statsLoading,
+    totalGames,
+    lastGameDate,
+  } = useProfileStats(supabase, user.id);
 
   const handleUpdateEmail = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,40 +208,65 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
   };
 
   return (
-    <div className="w-[300px] mx-auto bg-white dark:bg-gray-800 rounded shadow-md">
-      <div className="p-3 dark:text-gray-100">
-        {error && (
-          <div className="bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
-            {error}
-          </div>
-        )}
+    <div className="max-w-2xl mx-auto">
+      {/* Page header — matches the kicker + title pattern used on Setup
+          and Stats so the auth-gated screens share visual language. */}
+      <div className="mb-5 text-center sm:text-left">
+        <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          Your Account
+        </p>
+        <h2 className="mt-1 text-2xl sm:text-3xl font-bold dark:text-white">
+          My Profile
+        </h2>
+      </div>
 
-        {message && (
-          <div className="bg-green-100 dark:bg-green-900/30 border border-green-400 dark:border-green-700 text-green-700 dark:text-green-400 px-3 py-2 rounded mb-4 animate-fade-in text-sm">
-            {message}
-          </div>
-        )}
+      {/* Status messages — inline above the cards so they're impossible
+          to miss regardless of which form fired them. */}
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/30 px-4 py-2.5 text-sm text-red-700 dark:text-red-200"
+        >
+          {error}
+        </div>
+      )}
+      {message && (
+        <div
+          role="status"
+          className="mb-4 rounded-lg border border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/30 px-4 py-2.5 text-sm text-green-700 dark:text-green-200"
+        >
+          {message}
+        </div>
+      )}
 
-        {/* Update Email Form */}
-        <div className="mb-4">
-          <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
-            Update Email
-          </h3>
-          <div className="mb-2">
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Current Email
-            </label>
-            <p className="text-sm text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-700 px-2 py-1.5 rounded border">
-              {user.email}
-            </p>
-          </div>
-          <form onSubmit={handleUpdateEmail} className="space-y-2">
+      <div className="space-y-4">
+        {/* Account overview — give the page some "show", not just "set".
+            Previously Profile dropped users straight into edit forms with
+            zero context; basic facts orient the page. */}
+        <SectionCard heading="Account">
+          <dl className="divide-y divide-gray-100 dark:divide-gray-700">
+            <Field label="Email">{user.email}</Field>
+            <Field label="Member since">{formatMemberSince(user.created_at)}</Field>
+            <Field label="Games played">{statsLoading ? '—' : totalGames}</Field>
+            <Field label="Last game">
+              {statsLoading
+                ? '—'
+                : lastGameDate
+                  ? formatGameDateTime(lastGameDate)
+                  : 'Never'}
+            </Field>
+          </dl>
+        </SectionCard>
+
+        {/* Change email */}
+        <SectionCard heading="Change email">
+          <form onSubmit={handleUpdateEmail} className="space-y-3">
             <div>
               <label
                 htmlFor="new-email"
                 className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
               >
-                New Email
+                New email
               </label>
               <input
                 id="new-email"
@@ -128,60 +274,33 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
                 value={newEmail}
                 onChange={(e) => setNewEmail(e.target.value)}
                 required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Enter new email"
                 disabled={loading}
+                placeholder="you@example.com"
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
               />
             </div>
-
-            <button
-              type="submit"
-              className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <svg
-                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Updating...
-                </>
-              ) : (
-                'Update Email'
-              )}
-            </button>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={loading || !newEmail}
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading && <SubmitSpinner />}
+                {loading ? 'Updating…' : 'Update email'}
+              </button>
+            </div>
           </form>
-        </div>
+        </SectionCard>
 
-        {/* Update Password Form */}
-        <div className="mb-4">
-          <h3 className="text-base font-medium mb-2 border-b dark:border-gray-700 pb-1">
-            Update Password
-          </h3>
-          <form onSubmit={handleUpdatePassword} className="space-y-2">
+        {/* Change password */}
+        <SectionCard heading="Change password">
+          <form onSubmit={handleUpdatePassword} className="space-y-3">
             <div>
               <label
                 htmlFor="new-password"
                 className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
               >
-                New Password
+                New password
               </label>
               <input
                 id="new-password"
@@ -189,18 +308,16 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
                 required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Enter new password"
                 disabled={loading}
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
               />
             </div>
-
             <div>
               <label
                 htmlFor="confirm-password"
                 className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
               >
-                Confirm Password
+                Confirm new password
               </label>
               <input
                 id="confirm-password"
@@ -208,106 +325,112 @@ const UserProfile: React.FC<UserProfileProps> = ({ supabase, user, onSignOut }) 
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 required
-                className="w-full px-2 py-1.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200 text-sm"
-                placeholder="Confirm new password"
                 disabled={loading}
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
               />
             </div>
-
-            <button
-              type="submit"
-              className="w-full bg-blue-600 text-white py-1.5 px-2 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50 flex items-center justify-center text-sm"
-              disabled={loading}
-            >
-              {loading ? (
-                <>
-                  <svg
-                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    ></circle>
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    ></path>
-                  </svg>
-                  Updating...
-                </>
-              ) : (
-                'Update Password'
-              )}
-            </button>
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={loading || !newPassword || !confirmPassword}
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {loading && <SubmitSpinner />}
+                {loading ? 'Updating…' : 'Update password'}
+              </button>
+            </div>
           </form>
-        </div>
+        </SectionCard>
+      </div>
 
-        {/* Sign Out Button */}
+      {/* Sign out — demoted to a quiet outline pill in the page footer.
+          The previous full-width red button gave a benign action the
+          visual weight of a destructive one. */}
+      <div className="mt-6 flex justify-end">
         <button
           onClick={() => setShowSignOutConfirm(true)}
-          className="w-full bg-red-600 text-white py-1.5 px-2 rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm"
+          className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 px-3 py-1.5 text-sm font-medium transition-colors"
         >
-          Sign Out
+          <svg
+            className="w-3.5 h-3.5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+            />
+          </svg>
+          Sign out
         </button>
       </div>
 
-      {/* Sign Out Confirmation Modal */}
+      {/* Sign-out confirmation modal */}
       {showSignOutConfirm && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded p-4 w-[320px] mx-4">
-            <h3 className="text-base font-medium text-gray-900 dark:text-white mb-3">
-              Confirm Sign Out
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="signout-confirm-title"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-sm p-5">
+            <h3
+              id="signout-confirm-title"
+              className="text-base font-semibold text-gray-900 dark:text-white mb-2"
+            >
+              Sign out?
             </h3>
-            <p className="text-gray-600 dark:text-gray-300 mb-4 text-sm">
-              Are you sure you want to sign out?
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+              You'll need to sign back in to view your game history and profile.
             </p>
-            <div className="flex justify-end space-x-2">
+            <div className="flex justify-end gap-2">
               <button
                 onClick={() => setShowSignOutConfirm(false)}
-                className="px-3 py-1.5 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white text-sm"
+                className="px-3 py-1.5 text-sm rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSignOut}
-                className="px-3 py-1.5 bg-red-600 text-white rounded hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 text-sm"
+                className="px-3 py-1.5 text-sm rounded-md bg-blue-600 hover:bg-blue-700 text-white font-medium transition-colors"
               >
-                Sign Out
+                Sign out
               </button>
             </div>
           </div>
         </div>
       )}
 
-      {/* Success Animation */}
+      {/* Success animation */}
       {showSuccessAnimation && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-sm w-full mx-4 text-center">
-            <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-sm w-full text-center">
+            <div className="w-14 h-14 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
               <svg
-                className="w-8 h-8 text-green-500"
+                className="w-7 h-7 text-green-500"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  strokeWidth="2"
+                  strokeWidth={2}
                   d="M5 13l4 4L19 7"
-                ></path>
+                />
               </svg>
             </div>
-            <p className="text-gray-900 dark:text-white font-medium">Success!</p>
-            <p className="text-gray-600 dark:text-gray-300 text-sm mt-2">
+            <p className="text-gray-900 dark:text-white font-semibold">Success!</p>
+            <p className="text-gray-600 dark:text-gray-300 text-sm mt-1">
               Your changes have been saved.
             </p>
           </div>

--- a/src/components/modals/AuthModal.tsx
+++ b/src/components/modals/AuthModal.tsx
@@ -1,6 +1,6 @@
-import type { FC } from 'react';
+import { useState, type FC } from 'react';
 
-import Auth from '../auth/Auth';
+import Auth, { type AuthTab } from '../auth/Auth';
 
 import type { GameState } from '../../hooks/useGameState';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -12,27 +12,71 @@ interface AuthModalProps {
   onClose: () => void;
 }
 
+const TAB_TITLES: Record<AuthTab, string> = {
+  login: 'Welcome back',
+  signup: 'Create your account',
+  'reset-password': 'Reset your password',
+};
+
+const TAB_SUBTITLES: Record<AuthTab, string | null> = {
+  login: 'Sign in to access your game history.',
+  signup: 'Save your games and track stats across devices.',
+  'reset-password': "We'll email you a link to set a new password.",
+};
+
 export const AuthModal: FC<AuthModalProps> = ({
   isOpen,
   gameState,
   supabase,
   onClose,
 }) => {
+  const [activeTab, setActiveTab] = useState<AuthTab>('login');
+
   if (!isOpen) return null;
 
+  // The "Benefits of logging in" sales pitch makes sense for someone
+  // deciding to commit (Login or Sign Up). It's irrelevant to someone
+  // who's already a user trying to recover access (Reset Password) —
+  // they made their decision long ago.
+  const showBenefitsPanel = activeTab !== 'reset-password';
+
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm sm:max-w-lg w-full relative max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-2 sm:p-4">
+      <div
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm sm:max-w-lg w-full relative max-h-[90vh] overflow-y-auto"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auth-modal-title"
+      >
         <button
           onClick={onClose}
-          className="absolute top-3 right-3 z-10 w-7 h-7 flex items-center justify-center rounded-full bg-black bg-opacity-20 hover:bg-opacity-30 text-white transition-colors"
+          className="absolute top-3 right-3 z-10 w-7 h-7 flex items-center justify-center rounded-full bg-black/30 hover:bg-black/50 text-white transition-colors"
+          aria-label="Close authentication"
         >
           ✕
         </button>
-        <div className="p-4 sm:p-6 text-center bg-gray-100 dark:bg-gray-700 rounded-t-2xl">
-          <h2 className="text-lg sm:text-xl font-bold dark:text-white">Authentication</h2>
+
+        {/* Per-tab modal header — replaces the previous cold "Authentication"
+            heading. The subtitle gives the user a one-line cue about what
+            this tab will do. */}
+        <div className="p-4 sm:p-5 text-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-700/60 dark:to-gray-700/30 rounded-t-2xl border-b border-gray-200 dark:border-gray-700">
+          <h2
+            id="auth-modal-title"
+            className="text-lg sm:text-xl font-bold dark:text-white"
+          >
+            {TAB_TITLES[activeTab]}
+          </h2>
+          {TAB_SUBTITLES[activeTab] && (
+            <p className="mt-1 text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+              {TAB_SUBTITLES[activeTab]}
+            </p>
+          )}
         </div>
+
         <div className="p-3 sm:p-4">
+          {/* Mid-game prompt: take precedence over the benefits panel
+              because saving the in-flight game is the more compelling reason
+              to authenticate right now. */}
           {gameState === 'scoring' || gameState === 'statistics' ? (
             <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900 text-blue-800 dark:text-blue-100 rounded-lg text-sm">
               <p>
@@ -41,17 +85,25 @@ export const AuthModal: FC<AuthModalProps> = ({
               </p>
             </div>
           ) : (
-            <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-800 dark:text-green-100 rounded-lg text-sm">
-              <p className="font-semibold mb-2">Benefits of logging in:</p>
-              <ul className="list-disc list-inside space-y-1">
-                <li>Save your game history across devices</li>
-                <li>Track your statistics and progress</li>
-                <li>Never lose your game data</li>
-                <li>Access your games from anywhere</li>
-              </ul>
-            </div>
+            showBenefitsPanel && (
+              <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-800 dark:text-green-100 rounded-lg text-sm">
+                <p className="font-semibold mb-2">Benefits of logging in:</p>
+                <ul className="list-disc list-inside space-y-1">
+                  <li>Save your game history across devices</li>
+                  <li>Track your statistics and progress</li>
+                  <li>Never lose your game data</li>
+                  <li>Access your games from anywhere</li>
+                </ul>
+              </div>
+            )
           )}
-          <Auth supabase={supabase} onAuthSuccess={onClose} />
+
+          <Auth
+            supabase={supabase}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            onAuthSuccess={onClose}
+          />
         </div>
       </div>
     </div>

--- a/src/components/shared/GameSummaryPanel.tsx
+++ b/src/components/shared/GameSummaryPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { type Player, type GameAction } from '../../types/game';
+import { formatGameDateTime } from '../../utils/formatGameDate';
 
 import { type StatCalculator, type PlayerStats } from './types';
 
@@ -48,17 +49,7 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
   onShowDescriptions,
   copySuccess,
 }) => {
-  const gameDate = new Date(date);
-  const dayOfWeek = gameDate.toLocaleDateString('en-US', { weekday: 'short' });
-  const formattedDate = gameDate.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  });
-  const formattedTime = gameDate.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
+  const formattedDateTime = formatGameDateTime(date);
 
   const sortedPlayers = [...players].sort((a, b) => {
     if (a.id === winnerId) return -1;
@@ -100,9 +91,7 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
           {status.label}
         </div>
         <div className="text-sm text-gray-500 dark:text-gray-400">
-          {completed
-            ? `${dayOfWeek}, ${formattedDate} · ${formattedTime}`
-            : 'Not completed'}
+          {completed ? formattedDateTime : 'Not completed'}
         </div>
       </div>
 

--- a/src/components/shared/GameSummaryPanel.tsx
+++ b/src/components/shared/GameSummaryPanel.tsx
@@ -72,6 +72,23 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
     statsMap.set(player.id, calculatePlayerStats(player, actions));
   });
 
+  // Three status variants: completed-with-winner, ended-without-winner, in-progress.
+  const hasWinner = winnerId !== null && winnerId !== undefined;
+  const status = !completed
+    ? {
+        label: 'In Progress',
+        classes: 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200',
+      }
+    : hasWinner
+      ? {
+          label: 'Completed',
+          classes: 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200',
+        }
+      : {
+          label: 'Ended',
+          classes: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200',
+        };
+
   return (
     <div
       className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-6 overflow-hidden"
@@ -79,48 +96,54 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
     >
       {/* Status Header */}
       <div className="flex justify-between items-center px-4 py-3 border-b border-gray-100 dark:border-gray-700">
-        <div
-          className={`px-3 py-1 rounded-full text-xs font-medium ${
-            completed
-              ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
-              : 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200'
-          }`}
-        >
-          {completed ? 'Completed' : 'In Progress'}
+        <div className={`px-3 py-1 rounded-full text-xs font-medium ${status.classes}`}>
+          {status.label}
         </div>
         <div className="text-sm text-gray-500 dark:text-gray-400">
           {completed
-            ? `${dayOfWeek}, ${formattedDate} ${formattedTime}`
+            ? `${dayOfWeek}, ${formattedDate} · ${formattedTime}`
             : 'Not completed'}
         </div>
       </div>
 
       {/* Score Cards */}
       <div className="grid grid-cols-2 gap-3 p-4">
-        {sortedPlayers.map((player) => (
-          <div
-            key={player.id}
-            className={`p-3 rounded-lg ${
-              player.id === winnerId
-                ? 'border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/30'
-                : 'border-l-4 border-transparent bg-gray-50 dark:bg-gray-700/50'
-            }`}
-          >
-            <div className="flex items-center justify-between mb-1">
-              <span className="font-semibold text-sm dark:text-white">{player.name}</span>
-              {player.id === winnerId && (
-                <span className="text-yellow-500 text-sm">🏆</span>
-              )}
+        {sortedPlayers.map((player) => {
+          const isWinner = player.id === winnerId;
+          return (
+            <div
+              key={player.id}
+              className={`relative p-3 rounded-lg border ${
+                isWinner
+                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/40 ring-1 ring-blue-500/30'
+                  : 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-700/50'
+              }`}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <span
+                  className={`text-sm dark:text-white ${
+                    isWinner ? 'font-bold' : 'font-semibold'
+                  }`}
+                >
+                  {player.name}
+                </span>
+                {isWinner && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 dark:bg-yellow-900/50 px-2 py-0.5 text-[11px] font-semibold text-yellow-800 dark:text-yellow-200">
+                    <span aria-hidden="true">🏆</span>
+                    <span>Winner</span>
+                  </span>
+                )}
+              </div>
+              <div className="text-2xl font-bold dark:text-white">
+                {player.score}
+                <span className="text-sm font-normal text-gray-400 dark:text-gray-500">
+                  {' '}
+                  / {player.targetScore}
+                </span>
+              </div>
             </div>
-            <div className="text-2xl font-bold dark:text-white">
-              {player.score}
-              <span className="text-sm font-normal text-gray-400 dark:text-gray-500">
-                {' '}
-                / {player.targetScore}
-              </span>
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Metrics Table */}
@@ -131,14 +154,16 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
           </span>
           <button
             onClick={onShowDescriptions}
-            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-            title="View Statistic Descriptions"
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-gray-500 hover:text-gray-800 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-100 dark:hover:bg-gray-700 transition-colors"
+            title="View statistic descriptions"
+            aria-label="View statistic descriptions"
           >
             <svg
-              className="w-4 h-4"
+              className="w-3.5 h-3.5"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -147,6 +172,7 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
                 d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
               />
             </svg>
+            <span>What do these mean?</span>
           </button>
         </div>
         <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
@@ -157,7 +183,7 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
                 {sortedPlayers.map((player) => (
                   <th
                     key={player.id}
-                    className="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"
+                    className="px-3 py-2 text-left text-sm font-semibold text-gray-700 dark:text-gray-200"
                   >
                     {player.name}
                   </th>
@@ -195,7 +221,7 @@ export const GameSummaryPanel: React.FC<GameSummaryPanelProps> = ({
             <span className="font-medium">Length:</span> {matchLength}
           </span>
           <span>
-            <span className="font-medium">Innings:</span>{' '}
+            <span className="font-medium">Total Innings:</span>{' '}
             {Math.max(...players.map((p) => p.innings))}
           </span>
         </div>

--- a/src/utils/__tests__/computeMatchLength.test.ts
+++ b/src/utils/__tests__/computeMatchLength.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { type GameData } from '../../types/game';
+import { computeMatchLength } from '../computeMatchLength';
+
+const makeGame = (overrides: Partial<GameData> = {}): GameData => ({
+  id: 'g1',
+  date: '2025-05-04T15:00:00.000Z',
+  players: [],
+  winner_id: null,
+  completed: true,
+  actions: [],
+  ...overrides,
+});
+
+describe('computeMatchLength', () => {
+  it('formats sub-minute durations in seconds', () => {
+    const game = makeGame({
+      startTime: '2025-05-04T15:00:00.000Z',
+      endTime: '2025-05-04T15:00:42.000Z',
+    });
+    expect(computeMatchLength(game)).toBe('42s');
+  });
+
+  it('clamps zero duration to "1s" so test/short games never read as missing', () => {
+    const game = makeGame({
+      startTime: '2025-05-04T15:00:00.000Z',
+      endTime: '2025-05-04T15:00:00.000Z',
+    });
+    expect(computeMatchLength(game)).toBe('1s');
+  });
+
+  it('formats sub-hour durations in whole minutes', () => {
+    const game = makeGame({
+      startTime: '2025-05-04T15:00:00.000Z',
+      endTime: '2025-05-04T15:23:00.000Z',
+    });
+    expect(computeMatchLength(game)).toBe('23m');
+  });
+
+  it('formats multi-hour durations as "Nh Nm"', () => {
+    const game = makeGame({
+      startTime: '2025-05-04T15:00:00.000Z',
+      endTime: '2025-05-04T16:35:00.000Z',
+    });
+    expect(computeMatchLength(game)).toBe('1h 35m');
+  });
+
+  it('returns "—" for completed legacy games with no endTime', () => {
+    // Pre-time-tracking-columns games: only `date` is set. We genuinely
+    // don't know how long the game took — surface that honestly rather
+    // than rendering a misleading "0h 0m".
+    const game = makeGame({
+      completed: true,
+      startTime: undefined,
+      endTime: undefined,
+    });
+    expect(computeMatchLength(game)).toBe('—');
+  });
+
+  it('measures live elapsed time for in-progress games', () => {
+    // Freeze "now" so the assertion is deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-05-04T15:30:00.000Z'));
+
+    const game = makeGame({
+      completed: false,
+      startTime: '2025-05-04T15:25:00.000Z',
+      endTime: undefined,
+    });
+    expect(computeMatchLength(game)).toBe('5m');
+  });
+
+  it('falls back to game.date when startTime is missing', () => {
+    const game = makeGame({
+      date: '2025-05-04T15:00:00.000Z',
+      startTime: undefined,
+      endTime: '2025-05-04T15:12:00.000Z',
+    });
+    expect(computeMatchLength(game)).toBe('12m');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+});

--- a/src/utils/__tests__/formatGameDate.test.ts
+++ b/src/utils/__tests__/formatGameDate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatGameDateLong, formatGameDateTime } from '../formatGameDate';
+
+// Use a fixed local-friendly date so the format is predictable across runs.
+// 2025-05-04T15:18:00 in the local time zone — the assertions check shape,
+// not absolute time, so DST/timezone wiggle doesn't break them.
+const sample = new Date(2025, 4, 4, 15, 18, 0);
+
+describe('formatGameDateTime', () => {
+  it('renders the short interpunct form used across the UI', () => {
+    expect(formatGameDateTime(sample)).toBe('Sun, May 4 · 3:18 PM');
+  });
+
+  it('accepts a string input (Supabase returns ISO strings)', () => {
+    const iso = sample.toISOString();
+    const result = formatGameDateTime(iso);
+    expect(result).toMatch(
+      /^[A-Z][a-z]{2}, [A-Z][a-z]{2} \d{1,2} · \d{1,2}:\d{2} (AM|PM)$/,
+    );
+  });
+
+  it('accepts a number (epoch ms) input', () => {
+    const result = formatGameDateTime(sample.getTime());
+    expect(result).toBe('Sun, May 4 · 3:18 PM');
+  });
+});
+
+describe('formatGameDateLong', () => {
+  it('renders the verbose "at" form used in copy/email exports', () => {
+    expect(formatGameDateLong(sample)).toBe('Sunday, May 4 at 3:18 PM');
+  });
+
+  it('accepts a string input', () => {
+    const iso = sample.toISOString();
+    const result = formatGameDateLong(iso);
+    expect(result).toMatch(/^[A-Z][a-z]+, [A-Z][a-z]+ \d{1,2} at \d{1,2}:\d{2} (AM|PM)$/);
+  });
+});

--- a/src/utils/computeMatchLength.ts
+++ b/src/utils/computeMatchLength.ts
@@ -1,0 +1,37 @@
+import { type GameData } from '../types/game';
+
+/**
+ * Compute a human-readable match length from a game's start/end timestamps.
+ *
+ * Falls back gracefully when the explicit timestamps aren't present:
+ *   - If `startTime` is missing, we use `date` (legacy games stored before
+ *     the dedicated time-tracking columns shipped).
+ *   - If `endTime` is missing AND the game is in progress, we treat "now"
+ *     as the end and return live elapsed time.
+ *   - If `endTime` is missing AND the game is completed, we return "—" —
+ *     we genuinely don't know how long the game took (only when it was
+ *     recorded), and showing "0h 0m" was the bug we're fixing.
+ *
+ * Output format adapts to magnitude:
+ *   - Sub-minute → "Ns" (avoids "0m" for short test games)
+ *   - Sub-hour → "Nm"
+ *   - Otherwise → "Nh Nm"
+ */
+export const computeMatchLength = (game: GameData): string => {
+  const startSrc = game.startTime ?? game.date;
+  const endSrc = game.endTime ?? (game.completed ? null : new Date());
+  if (!startSrc || !endSrc) return '—';
+
+  const start = new Date(startSrc);
+  const end = new Date(endSrc);
+  const diffMs = Math.max(0, end.getTime() - start.getTime());
+
+  if (diffMs < 60 * 1000) {
+    const seconds = Math.max(1, Math.floor(diffMs / 1000));
+    return `${seconds}s`;
+  }
+
+  const hours = Math.floor(diffMs / (1000 * 60 * 60));
+  const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+};

--- a/src/utils/formatGameDate.ts
+++ b/src/utils/formatGameDate.ts
@@ -1,0 +1,56 @@
+/**
+ * Date-formatting helpers for game records.
+ *
+ * Two formats are exposed:
+ *   - `formatGameDateTime` is the short, scannable form used everywhere a
+ *     game date is shown in the UI (Stats header, History list/detail,
+ *     GameSummaryPanel).
+ *   - `formatGameDateLong` is the verbose form used in copy-to-clipboard
+ *     exports where the receiver is reading prose and verbosity helps.
+ *
+ * Keeping both forms in one module makes the convention discoverable: any
+ * new screen that needs to render a game date should reach for
+ * `formatGameDateTime` first.
+ */
+
+type DateInput = Date | string | number;
+
+/**
+ * "Sun, May 3 · 3:18 AM" — short form for in-app display.
+ * Matches the format originally introduced by GameSummaryPanel; we
+ * standardize the rest of the app on this so the date doesn't change shape
+ * as the user moves between screens.
+ */
+export const formatGameDateTime = (input: DateInput): string => {
+  const date = new Date(input);
+  const dayOfWeek = date.toLocaleDateString('en-US', { weekday: 'short' });
+  const monthDay = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+  const time = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${dayOfWeek}, ${monthDay} · ${time}`;
+};
+
+/**
+ * "Sunday, May 3 at 3:18 AM" — verbose form for export/email contexts where
+ * the date is consumed as prose.
+ */
+export const formatGameDateLong = (input: DateInput): string => {
+  const date = new Date(input);
+  const formattedDate = date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+  const formattedTime = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${formattedDate} at ${formattedTime}`;
+};

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,168 @@
+-- RunCount initial schema bootstrap.
+--
+-- This file is a faithful re-creation of the original production schema
+-- (extracted from db_cluster-23-08-2025@07-33-43.backup.gz, the last cluster
+-- backup before the project was paused), with three deliberate additions
+-- noted inline below.
+--
+-- Idempotent: safe to re-run on an existing project. Designed to be pasted
+-- into the Supabase Dashboard SQL Editor on a freshly-created project.
+--
+-- Schema surface area:
+--   * One table: public.games
+--   * RLS so each user only sees their own games
+--   * Realtime publication membership (which production was MISSING — see
+--     the "Realtime" section)
+--   * Auth is fully managed by Supabase (no custom profiles table; profile
+--     fields live in auth.users.user_metadata)
+--
+-- Deliberate divergence from the Aug 2025 production schema:
+--   1. Adds three camelCase columns ("startTime", "endTime", "turnStartTime")
+--      which the current client code references in the upsert payload but
+--      which post-date the backup.
+--   2. Adds public.games to the supabase_realtime publication. The History
+--      screen's realtime subscription was silently a no-op in production
+--      because games was never published. This bootstrap fixes that.
+--   3. Adds ON DELETE CASCADE on the owner_id FK so deleting an auth user
+--      doesn't leave orphan games (production used the default NO ACTION,
+--      which would block account deletion entirely).
+--   4. Adds an (owner_id, date desc) partial index. Production had none.
+
+-- ---------------------------------------------------------------------------
+-- Extensions (gen_random_uuid lives in the extensions schema on Supabase,
+-- which is preinstalled — this is a defensive no-op on hosted Supabase).
+-- ---------------------------------------------------------------------------
+
+create extension if not exists "pgcrypto";
+
+-- ---------------------------------------------------------------------------
+-- Table: public.games
+-- ---------------------------------------------------------------------------
+--
+-- Column naming note: the wire format mixes snake_case (winner_id, owner_id)
+-- with camelCase ("startTime", "endTime", "turnStartTime") because the
+-- client upserts a JS object directly. Camel-cased identifiers must be
+-- double-quoted in SQL — do NOT rename without changing the client.
+
+create table if not exists public.games (
+    id              uuid default gen_random_uuid() not null,
+    date            timestamptz default now() not null,
+    players         jsonb,
+    actions         jsonb,
+    completed       boolean,
+    winner_id       integer,
+    owner_id        uuid,
+    deleted         boolean default false,
+    "startTime"     timestamptz,
+    "endTime"       timestamptz,
+    "turnStartTime" timestamptz
+);
+
+alter table public.games owner to postgres;
+
+-- Add the camelCase time columns conditionally in case this is being run
+-- against a pre-existing table created from the older production schema.
+alter table public.games add column if not exists "startTime"     timestamptz;
+alter table public.games add column if not exists "endTime"       timestamptz;
+alter table public.games add column if not exists "turnStartTime" timestamptz;
+
+-- ---------------------------------------------------------------------------
+-- Constraints
+-- ---------------------------------------------------------------------------
+
+-- PRIMARY KEY on id. `if not exists` syntax isn't available for ADD CONSTRAINT,
+-- so guard it with a DO block.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'games_pkey' and conrelid = 'public.games'::regclass
+  ) then
+    alter table only public.games add constraint games_pkey primary key (id);
+  end if;
+end$$;
+
+-- FK to auth.users. Production used the default ON DELETE NO ACTION, which
+-- means deleting a user with games would fail. CASCADE is friendlier.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'games_owner_id_fkey' and conrelid = 'public.games'::regclass
+  ) then
+    alter table only public.games
+      add constraint games_owner_id_fkey
+      foreign key (owner_id) references auth.users(id) on delete cascade;
+  end if;
+end$$;
+
+-- ---------------------------------------------------------------------------
+-- Indexes
+-- ---------------------------------------------------------------------------
+
+-- Accelerates the History query:
+--   SELECT * FROM games WHERE owner_id = ? AND deleted = false ORDER BY date DESC
+create index if not exists games_owner_date_idx
+    on public.games (owner_id, date desc)
+    where deleted = false;
+
+-- ---------------------------------------------------------------------------
+-- Privileges (Supabase defaults — explicit for parity with production dump)
+-- ---------------------------------------------------------------------------
+
+grant all on table public.games to anon;
+grant all on table public.games to authenticated;
+grant all on table public.games to service_role;
+
+-- ---------------------------------------------------------------------------
+-- Row Level Security (policy names match the production dump)
+-- ---------------------------------------------------------------------------
+
+alter table public.games enable row level security;
+
+drop policy if exists "Users can read their own records" on public.games;
+create policy "Users can read their own records"
+    on public.games for select
+    to authenticated
+    using ((auth.uid() = owner_id));
+
+drop policy if exists "Users can insert their own records" on public.games;
+create policy "Users can insert their own records"
+    on public.games for insert
+    to authenticated
+    with check ((auth.uid() = owner_id));
+
+drop policy if exists "Users can update their own records" on public.games;
+create policy "Users can update their own records"
+    on public.games for update
+    to authenticated
+    using ((auth.uid() = owner_id));
+
+drop policy if exists "Users can delete their own records" on public.games;
+create policy "Users can delete their own records"
+    on public.games for delete
+    to authenticated
+    using ((auth.uid() = owner_id));
+
+-- ---------------------------------------------------------------------------
+-- Realtime
+-- ---------------------------------------------------------------------------
+--
+-- KNOWN PROD ISSUE: the original production project never added public.games
+-- to the supabase_realtime publication, which means the History screen's
+-- postgres_changes subscription (src/components/GameHistory/hooks/useGameHistory.ts)
+-- was silently a no-op. We add it here so the new project has working
+-- realtime from day one.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'games'
+  ) then
+    alter publication supabase_realtime add table public.games;
+  end if;
+end$$;


### PR DESCRIPTION
## Summary

- **Six screens redesigned** to share visual language: Setup, Scoring, Statistics, History, My Profile, and Auth modals
- **Two real bug fixes** discovered during the review: match-length showing `0h 0m` on Statistics and History detail
- **Fresh Supabase project bootstrap** (`supabase/schema.sql`) since the original was paused 90+ days and removed past the dashboard's self-serve restore window
- **Fixes a stale `.env` footgun** where `REACT_APP_*` vars from the Create-React-App era were being silently ignored by Vite

## Why

The user wasn't happy with the design and asked for a screen-by-screen review with proposed fixes per screen. Mid-review, the Supabase backend went dark — the project had been paused so long it could no longer be self-serve restored — so we also bootstrapped a new project in parallel. Took the opportunity to fix infrastructure footguns surfaced along the way.

## What changed

### Design refresh (per screen)

**Setup** — kicker + bold title pattern (`14.1 STRAIGHT POOL SCORER` → `New Game`), prominent "🎱 Breaking" pill on the breaker card, neutral shot-clock pills, single-tab nav hidden when signed out.

**Scoring** — equal-height player cards with actions extracted into a unified zone (`Miss` primary + `Safety/Foul/+Rack` qualifier row), BOT as inline status text (no longer fake-interactive), tight utility row (`Innings | Undo | End Game | ?`), three-state shot clock (neutral → amber → red instead of always-orange).

**Statistics** — contextual headline replacing generic h2 (`Alice wins 1–0` / `Game tied` / `Alice ahead`), `+ Start New Game` CTA added (was a dead-end screen), three-state status badge, prominent `🏆 Winner` pill.
*Bug fix:* `Length: 0h 0m` was using `gameData.date` for both endpoints — now uses real `startTime`/`endTime`.

**History** (this PR's biggest screen)
- New list-card design uses the same visual language as `GameSummaryPanel` — status pill, trophy + bold winner, length + innings footer, hover-revealed `View details →`
- Empty-state branching: "No games yet" hero (with primary CTA) vs "No games match the current filters" — previously both used the same misleading filtered copy
- Filter toolbar hidden when zero games, header CTAs hidden when zero games (the empty-state hero carries its own CTA)
- "Showing X of Y" only renders when a filter is actually narrowing
- Export CSV/JSON demoted from neon green/purple to muted neutrals with download icons
- *Bug fix:* `GameDetails.tsx` had the same `0h 0m` length bug as Statistics — same `computeMatchLength` helper now shared

**My Profile** — kicker + bold title, new Account overview card (Email / Member since / Games played / Last game) above the edit forms, three sectioned cards instead of one glued panel, Sign Out demoted from full-width red destructive button to a quiet outline pill in the page footer. Sign-out confirm modal restyled (neutral + blue, blurred backdrop, helpful subtitle).

**Auth modals** — per-tab modal titles (`Welcome back` / `Create your account` / `Reset your password`) with subtitles, "Forgot password?" link below the Login form, "Reset Password" tab shortened to "Reset" (no longer wraps), benefits panel hidden on Reset Password (irrelevant to recovery), pill-segment tab control, ARIA cleanup.

### Shared infrastructure

- New `src/utils/formatGameDate.ts` — `formatGameDateTime` for in-app display, `formatGameDateLong` for copy/email exports. Replaces four inline `toLocaleDateString` call sites that rendered the date three different ways.
- New `src/utils/computeMatchLength.ts` — extracted from inline helper; honors `startTime`/`endTime` and falls back to `'—'` for legacy games rather than misleading `0h 0m`.
- 12 new unit tests for both utilities including legacy-game fallback and live-elapsed timing for in-progress games.

### Supabase recovery

- `supabase/schema.sql` — pasteable bootstrap that recreates `public.games`, RLS policies, `(owner_id, date desc)` partial index, and adds the table to `supabase_realtime` publication. Faithful to the Aug 2025 cluster backup with four documented divergences (the three camelCase time columns required by current code, the realtime publication membership which production was silently missing, `ON DELETE CASCADE` on `owner_id`, and the new index).
- **Bonus production-bug discovery:** the original Aug 2025 schema **never added `public.games` to the `supabase_realtime` publication** — meaning the History screen's realtime subscription has been silently dead in production since launch. Bootstrap fixes this for the new project.
- `.env.example` — committable template documenting the `VITE_*` variable names. Fixes a long-standing footgun where the gitignored `.env` still used the legacy `REACT_APP_*` prefix that Vite silently ignores.

## Required action after merge

The deploy workflow reads two GitHub secrets that need updating to point at the new Supabase project before the next deploy of `main`:

```bash
gh secret set SUPABASE_URL --body "https://svggdaugfjvtlapsnavz.supabase.co"
gh secret set SUPABASE_ANON_KEY  # paste anon key at the prompt
```

Until these are updated, deploys will continue building against the dead old project's secrets and the deployed bundle will fail at runtime with `supabaseUrl is required` / connection errors.

## Followups (intentionally out of scope)

Captured separately rather than bundled in:

- **Fix `authRedirect.ts` basepath bug** — helper builds redirect URLs from `window.location.origin` only, ignoring Vite's `base`. Hidden by production using `/`, but breaks any non-root deployment and the local dev preview.
- **Unify page-title pattern across screens** — small design-system pass to apply the kicker + bold title pattern everywhere.
- **Address desktop empty space** — mobile-first column leaves wide screens half-empty.
- **Consolidate Trends 4-chart grid into one multi-series chart** — remove redundancy, make the toggle pills do something.

## Test plan

- [x] `npm test` — 228/228 passing (43 test files), including 12 new tests for the extracted utilities
- [x] `npm run build` — clean, bundle hash `index-Cn62g4Je.js`
- [x] Pre-commit + pre-push hooks pass (eslint --max-warnings=0, prettier --write, full test suite)
- [x] Browser-validated end-to-end on `localhost:4173` against the new Supabase project: signup → email confirmation → sign in → play game → History list (new card design) → History detail (length bug fix verified: shows `28s` not `0h 0m`) → Trends (with one game) → Profile (account overview populated) → sign out (new modal) → all three auth modal tabs (Login / Sign Up / Reset)
- [x] Verified the realtime publication membership now includes `public.games` on the new project (will work for the first time end-to-end in production after merge + secret update)
- [ ] **Reviewer:** before merge, confirm you have a Supabase URL + anon key ready to drop into GitHub secrets — or expect the next deploy to ship a broken bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)