### PR TITLE
💄 Unify Trends page into single multi-series chart

### DIFF
--- a/src/components/Trends/__tests__/TrendsPage.test.tsx
+++ b/src/components/Trends/__tests__/TrendsPage.test.tsx
@@ -7,7 +7,9 @@ import TrendsPage from '../index';
 
 vi.mock('recharts', () => ({
   CartesianGrid: () => null,
-  Line: () => null,
+  Line: ({ dataKey }: { dataKey?: string }) => (
+    <div data-testid={`recharts-line-${dataKey}`} />
+  ),
   LineChart: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="recharts-linechart">{children}</div>
   ),
@@ -83,7 +85,7 @@ describe('TrendsPage', () => {
     expect(screen.getByText(/No completed games yet/i)).toBeInTheDocument();
   });
 
-  test('renders metric toggles and chart for the selected player', () => {
+  test('hides chart and shows minimum-games message when below threshold', () => {
     vi.spyOn(GameHistoryHook, 'useGameHistory').mockReturnValue({
       games: [
         buildGame({ id: 'g-1', date: '2026-04-01T12:00:00.000Z' }),
@@ -100,13 +102,13 @@ describe('TrendsPage', () => {
     expect(playerSelect.value).toBe('alice');
 
     expect(screen.getByText('Average BPI')).toBeInTheDocument();
-    expect(screen.getByText('Win rate')).toBeInTheDocument();
-
-    const charts = screen.getAllByTestId('recharts-linechart');
-    expect(charts.length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Need at least 3 games to chart trends/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('recharts-linechart')).not.toBeInTheDocument();
   });
 
-  test('toggling a metric off removes its chart', () => {
+  test('renders one chart with all four series above the threshold', () => {
     vi.spyOn(GameHistoryHook, 'useGameHistory').mockReturnValue({
       games: [
         buildGame({ id: 'g-1', date: '2026-04-01T12:00:00.000Z' }),
@@ -120,12 +122,41 @@ describe('TrendsPage', () => {
 
     renderPage();
 
-    const initialCharts = screen.getAllByTestId('recharts-linechart');
-    expect(initialCharts.length).toBe(4);
+    expect(screen.getAllByTestId('recharts-linechart')).toHaveLength(1);
+    expect(screen.getByText(/Performance over time/i)).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-bpi')).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-shootingPercentage')).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-highRun')).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-safetyEfficiency')).toBeInTheDocument();
+  });
+
+  test('toggling a metric off hides only that series', () => {
+    vi.spyOn(GameHistoryHook, 'useGameHistory').mockReturnValue({
+      games: [
+        buildGame({ id: 'g-1', date: '2026-04-01T12:00:00.000Z' }),
+        buildGame({ id: 'g-2', date: '2026-04-05T12:00:00.000Z' }),
+        buildGame({ id: 'g-3', date: '2026-04-10T12:00:00.000Z' }),
+      ],
+      loading: false,
+      error: '',
+      deleteGame: vi.fn(),
+    } as any);
+
+    renderPage();
+
+    expect(screen.getByTestId('recharts-line-bpi')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /BPI/ }));
 
-    const remainingCharts = screen.getAllByTestId('recharts-linechart');
-    expect(remainingCharts.length).toBe(3);
+    expect(screen.queryByTestId('recharts-line-bpi')).not.toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-shootingPercentage')).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-highRun')).toBeInTheDocument();
+    expect(screen.getByTestId('recharts-line-safetyEfficiency')).toBeInTheDocument();
+    expect(screen.getAllByTestId('recharts-linechart')).toHaveLength(1);
+
+    expect(screen.getByRole('button', { name: /BPI/ })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
   });
 });

--- a/src/components/Trends/components/MetricToggle.tsx
+++ b/src/components/Trends/components/MetricToggle.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import type { CSSProperties, FC } from 'react';
 
 import type { TrendMetric } from '../utils/trendsData';
 
@@ -27,22 +27,28 @@ export const MetricToggle: FC<MetricToggleProps> = ({
     >
       {metrics.map((metric) => {
         const isActive = visibleMetrics.includes(metric.key);
+        const style: CSSProperties = {
+          borderColor: metric.color,
+          backgroundColor: isActive ? metric.color : undefined,
+        };
+        const stateClasses = isActive
+          ? 'text-white shadow-sm'
+          : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 opacity-60 hover:opacity-100';
         return (
           <button
             key={metric.key}
             type="button"
             onClick={() => onToggle(metric.key)}
             aria-pressed={isActive}
-            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
-              isActive
-                ? 'bg-blue-600 text-white border-blue-600'
-                : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-600'
-            }`}
+            style={style}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium border-2 transition-all ${stateClasses}`}
           >
             <span
               aria-hidden
               className="inline-block w-2 h-2 rounded-full mr-2 align-middle"
-              style={{ backgroundColor: metric.color }}
+              style={{
+                backgroundColor: isActive ? '#ffffff' : metric.color,
+              }}
             />
             {metric.label}
           </button>

--- a/src/components/Trends/components/TrendChart.tsx
+++ b/src/components/Trends/components/TrendChart.tsx
@@ -12,13 +12,17 @@ import {
 
 import type { PlayerTrendPoint, TrendMetric } from '../utils/trendsData';
 
-interface TrendChartProps {
-  title: string;
+export interface TrendSeries {
+  key: TrendMetric;
+  label: string;
   color: string;
-  metric: TrendMetric;
   unit?: string;
-  data: PlayerTrendPoint[];
   decimals?: number;
+}
+
+interface TrendChartProps {
+  data: PlayerTrendPoint[];
+  series: TrendSeries[];
 }
 
 const formatDateLabel = (timestamp: number) => {
@@ -26,27 +30,21 @@ const formatDateLabel = (timestamp: number) => {
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 };
 
-export const TrendChart: FC<TrendChartProps> = ({
-  title,
-  color,
-  metric,
-  unit = '',
-  data,
-  decimals = 0,
-}) => {
-  const formatValue = (value: number) => `${value.toFixed(decimals)}${unit}`;
+const formatSeriesValue = (value: number, entry: TrendSeries) =>
+  `${value.toFixed(entry.decimals ?? 0)}${entry.unit ?? ''}`;
 
+export const TrendChart: FC<TrendChartProps> = ({ data, series }) => {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-4">
-      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-2">
-        {title}
+      <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">
+        Performance over time
       </h3>
-      {data.length === 0 ? (
-        <p className="text-sm text-gray-500 dark:text-gray-400 py-12 text-center">
-          No completed games yet
+      {series.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400 py-16 text-center">
+          Select a metric above to see its trend.
         </p>
       ) : (
-        <ResponsiveContainer width="100%" height={220} minWidth={0}>
+        <ResponsiveContainer width="100%" height={320} minWidth={0}>
           <LineChart data={data} margin={{ top: 5, right: 12, bottom: 5, left: 0 }}>
             <CartesianGrid stroke="rgba(148, 163, 184, 0.25)" strokeDasharray="3 3" />
             <XAxis
@@ -56,12 +54,9 @@ export const TrendChart: FC<TrendChartProps> = ({
               tick={{ fontSize: 12 }}
               minTickGap={24}
             />
-            <YAxis
-              stroke="currentColor"
-              tick={{ fontSize: 12 }}
-              width={36}
-              tickFormatter={(value) => `${value}`}
-            />
+            {series.map((entry) => (
+              <YAxis key={entry.key} yAxisId={entry.key} hide domain={['auto', 'auto']} />
+            ))}
             <Tooltip
               labelFormatter={(label) =>
                 new Date(label as number).toLocaleString(undefined, {
@@ -70,7 +65,15 @@ export const TrendChart: FC<TrendChartProps> = ({
                   year: 'numeric',
                 })
               }
-              formatter={(value) => [formatValue(value as number), title]}
+              formatter={(value, _name, item) => {
+                const dataKey = (item as { dataKey?: string }).dataKey as
+                  | TrendMetric
+                  | undefined;
+                const matched = series.find((entry) => entry.key === dataKey);
+                if (!matched) return [String(value), String(_name)];
+                const numeric = typeof value === 'number' ? value : Number(value);
+                return [formatSeriesValue(numeric, matched), matched.label];
+              }}
               contentStyle={{
                 backgroundColor: 'rgba(17, 24, 39, 0.92)',
                 border: 'none',
@@ -80,15 +83,20 @@ export const TrendChart: FC<TrendChartProps> = ({
               itemStyle={{ color: '#f9fafb' }}
               labelStyle={{ color: '#d1d5db' }}
             />
-            <Line
-              type="monotone"
-              dataKey={metric}
-              stroke={color}
-              strokeWidth={2}
-              dot={{ r: 3, fill: color }}
-              activeDot={{ r: 5 }}
-              isAnimationActive={false}
-            />
+            {series.map((entry) => (
+              <Line
+                key={entry.key}
+                type="monotone"
+                yAxisId={entry.key}
+                dataKey={entry.key}
+                name={entry.label}
+                stroke={entry.color}
+                strokeWidth={2}
+                dot={{ r: 3, fill: entry.color }}
+                activeDot={{ r: 5 }}
+                isAnimationActive={false}
+              />
+            ))}
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/src/components/Trends/index.tsx
+++ b/src/components/Trends/index.tsx
@@ -5,10 +5,24 @@ import { type SupabaseClient, type User } from '@supabase/supabase-js';
 import { MetricToggle, type MetricDefinition } from './components/MetricToggle';
 import { PlayerSelector } from './components/PlayerSelector';
 import { SummaryCards } from './components/SummaryCards';
-import { TrendChart } from './components/TrendChart';
+import { TrendChart, type TrendSeries } from './components/TrendChart';
 import { useTrendsData } from './hooks/useTrendsData';
 
 import type { TrendMetric } from './utils/trendsData';
+
+const METRIC_DECIMALS: Record<TrendMetric, number> = {
+  bpi: 2,
+  shootingPercentage: 0,
+  highRun: 0,
+  safetyEfficiency: 0,
+};
+
+const METRIC_UNITS: Record<TrendMetric, string> = {
+  bpi: '',
+  shootingPercentage: '%',
+  highRun: '',
+  safetyEfficiency: '%',
+};
 
 interface TrendsPageProps {
   supabase: SupabaseClient;
@@ -51,8 +65,17 @@ const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => 
     );
   };
 
-  const visibleMetricDefinitions = useMemo(
-    () => METRIC_DEFINITIONS.filter((metric) => visibleMetrics.includes(metric.key)),
+  const visibleSeries = useMemo<TrendSeries[]>(
+    () =>
+      METRIC_DEFINITIONS.filter((metric) => visibleMetrics.includes(metric.key)).map(
+        (metric) => ({
+          key: metric.key,
+          label: metric.label,
+          color: metric.color,
+          decimals: METRIC_DECIMALS[metric.key],
+          unit: METRIC_UNITS[metric.key],
+        }),
+      ),
     [visibleMetrics],
   );
 
@@ -132,37 +155,17 @@ const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => 
                 hasEnoughForTrends={trendPoints.length >= TRENDS_DELTA_MIN_GAMES}
               />
 
-              {trendPoints.length < TRENDS_REQUIRED_GAMES && (
-                <p className="text-sm text-gray-500 dark:text-gray-400">
-                  Showing data from {trendPoints.length} completed game
-                  {trendPoints.length === 1 ? '' : 's'}. Play a few more for richer
-                  trends.
-                </p>
-              )}
-
-              {visibleMetricDefinitions.length === 0 ? (
-                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center text-sm text-gray-500 dark:text-gray-400">
-                  Select a metric above to see its trend.
+              {trendPoints.length < TRENDS_REQUIRED_GAMES ? (
+                <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 text-center text-gray-700 dark:text-gray-300">
+                  <p className="text-sm">
+                    Need at least {TRENDS_REQUIRED_GAMES} games to chart trends.
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {trendPoints.length} of {TRENDS_REQUIRED_GAMES} so far — keep playing.
+                  </p>
                 </div>
               ) : (
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                  {visibleMetricDefinitions.map((metric) => (
-                    <TrendChart
-                      key={metric.key}
-                      title={metric.label}
-                      color={metric.color}
-                      metric={metric.key}
-                      data={trendPoints}
-                      decimals={metric.key === 'bpi' ? 2 : 0}
-                      unit={
-                        metric.key === 'shootingPercentage' ||
-                        metric.key === 'safetyEfficiency'
-                          ? '%'
-                          : ''
-                      }
-                    />
-                  ))}
-                </div>
+                <TrendChart data={trendPoints} series={visibleSeries} />
               )}
             </>
           )}


### PR DESCRIPTION
## Summary

The Trends screen rendered four separate recharts tiles plus four series-toggle pills above them — but the pills had no visible effect, so they looked permanently "all on" and the four tiles were visually redundant. This refactor collapses them into one full-width "Performance over time" chart driven by real toggles.

- **One chart, four series.** The 2×2 grid of `TrendChart` instances is replaced with a single full-width chart. Each series renders against its own hidden `YAxis` (via `yAxisId`) so disparate ranges (BPI ~0–5 vs. percentages 0–100 vs. high-run counts) all stay visually comparable on a shared time axis.
- **Pills are real toggles now.** Active state is a solid pill in the metric's own color (blue / green / orange / pink) with a white interior dot; inactive is outlined with reduced opacity. `aria-pressed` reflects state. Clicking adds or removes that series from the chart.
- **Tooltip lists every visible series** for the hovered date, formatted with the right decimals + units per metric (BPI to 2dp, shooting/safety as `%`, high run as integer).
- **Bonus: 3-game floor.** When the player has fewer than 3 completed games, the chart is hidden and a "Need at least 3 games to chart trends" message takes its place — replaces the previous "Showing data from N completed games" hint that still rendered a single floating dot.
- The four stat cards above (Average BPI / Shooting % / High Run / Win Rate) are unchanged, as are `PlayerSelector` and the `useTrendsData` hook.

## Files

- `src/components/Trends/components/TrendChart.tsx` — new `series: TrendSeries[]` API; one chart, per-series hidden Y axes, multi-series tooltip.
- `src/components/Trends/components/MetricToggle.tsx` — color-aware active/inactive pill states with opacity transition.
- `src/components/Trends/index.tsx` — single chart render path + 3-game guard; metric formatting (decimals, units) lifted out of `TrendChart` so the chart stays presentational.
- `src/components/Trends/__tests__/TrendsPage.test.tsx` — recharts mock now exposes `Line` per `dataKey`; coverage for the threshold message, single-chart render, and per-series toggle.

## Test plan

- [x] `npx vitest run src/components/Trends/` — 12/12 pass
- [x] `npm run build` — clean
- [ ] Smoke-check in browser: pills toggle visibly, lines drop in/out of the chart, tooltip lists every visible series for a hovered date
- [ ] Smoke-check the < 3 games state shows the "Need at least 3 games to chart trends" message instead of a floating dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)