### PR TITLE
💄 Vertical-center page content on tall viewports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -182,7 +182,7 @@ const AppContent: FC = () => {
 
       <Navigation gameState={gameState} user={user} onNavigate={setGameState} />
 
-      <main className="flex-grow container mx-auto p-4">
+      <main className="flex-grow container mx-auto p-4 flex flex-col">
         <GameRouter
           gameState={gameState}
           supabase={supabase}

--- a/src/components/GameHistory/index.tsx
+++ b/src/components/GameHistory/index.tsx
@@ -178,7 +178,7 @@ const GameHistory: React.FC<GameHistoryProps> = ({
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-4xl w-full mx-auto my-auto">
       <DeleteConfirmationModal
         isOpen={showDeleteConfirmation}
         onCancel={cancelDelete}
@@ -225,7 +225,7 @@ const GameHistory: React.FC<GameHistoryProps> = ({
 
       {/* Conditionally render either the list or details view */}
       {view === 'list' ? (
-        <div className="min-h-[calc(100vh-15rem)]">
+        <div>
           {/* Filter / export toolbar — hidden entirely when the user has
               no games yet. The empty-state hero in GameList carries the
               "start your first game" call to action; surfacing five date
@@ -381,7 +381,7 @@ const GameHistory: React.FC<GameHistoryProps> = ({
           />
         </div>
       ) : (
-        <div className="min-h-[calc(100vh-15rem)]">
+        <div>
           {selectedGame ? (
             <GameDetails
               game={selectedGame}

--- a/src/components/GameScoring/index.tsx
+++ b/src/components/GameScoring/index.tsx
@@ -652,7 +652,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
   };
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-4xl w-full mx-auto my-auto">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         {playerData.map((player, index) => (
           <PlayerScoreCard

--- a/src/components/GameSetup.tsx
+++ b/src/components/GameSetup.tsx
@@ -88,7 +88,7 @@ const GameSetup: React.FC<GameSetupProps> = ({
   };
 
   return (
-    <div className="max-w-md mx-auto">
+    <div className="max-w-md w-full mx-auto my-auto">
       {/* Header */}
       <div className="text-center mb-6">
         <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-1">

--- a/src/components/GameStatistics.tsx
+++ b/src/components/GameStatistics.tsx
@@ -241,7 +241,7 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
   const headline = deriveHeadline(gameData);
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-4xl w-full mx-auto my-auto">
       <div className="mb-5 text-center sm:text-left">
         <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
           Game Result

--- a/src/components/Trends/index.tsx
+++ b/src/components/Trends/index.tsx
@@ -102,7 +102,7 @@ const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => 
   }
 
   return (
-    <div className="max-w-5xl mx-auto">
+    <div className="max-w-5xl w-full mx-auto my-auto">
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="text-center sm:text-left">
           <p className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -219,7 +219,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
   };
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="max-w-2xl w-full mx-auto my-auto">
       {/* Page header — matches the kicker + title pattern used on Setup
           and Stats so the auth-gated screens share visual language. Hidden
           when rendered inside ProfileModal (which has its own header). */}


### PR DESCRIPTION
## Summary

- Made `<main>` a flex column so each page can use `my-auto` to vertical-center its content. Fills the empty bottom half of iPad-landscape and desktop viewports without changing how things render on phone portrait, where content already overflows and `my-auto` resolves to zero (so the page scrolls normally instead of clipping the top).
- Applied the pattern to all five screens called out in the design pass: Setup, Scoring, History, Statistics, Trends, and Profile.
- Dropped GameHistory's `min-h-[calc(100vh-15rem)]` hack — the new centering replaces the reason it existed (reserving viewport height so short list/empty states didn't collapse upward).

## Why this and not desktop sidebars

Primary surfaces are phone portrait and iPad landscape. iPad landscape is ~1024×768, which doesn't have enough horizontal room to add a meaningful sidebar without squeezing the primary content column. Desktop viewers are rare. So instead of a split-screen reach, the page just centers its existing column — true desktop viewers get a "tidy island" rather than a stretched layout.

## Implementation note

`my-auto` (auto vertical margins on a flex item) is the right primitive here. `justify-content: center` would have clipped the top of a too-tall page on phones, since the overflow goes equally above and below the viewport. Auto margins resolve to 0 when the child outgrows the container, so phone portrait is unaffected.

10 lines changed across 7 files.

## Test plan

- [ ] Smoke-test on phone portrait (~390×844) — content should still sit at the top and scroll normally
- [ ] Check iPad landscape (~1024×768) — Setup, Scoring, Profile should feel vertically centered
- [ ] Check desktop (1280×900+) — empty states (Trends with no games, History with no games) should sit centered, not at top
- [ ] Verify the GameSetup gradient still extends to the page edges in light and dark mode