### PR TITLE
🐛 Fix stale e2e fixtures across game-flows and game-history specs

### DIFF
--- a/tests/e2e/game-flows.spec.ts
+++ b/tests/e2e/game-flows.spec.ts
@@ -78,14 +78,27 @@ test.describe('Straight pool core flows', () => {
     await startNewGame(page, { playerOneTarget: 10, playerTwoTarget: 10 });
 
     await completeRack(page, 1);
-    await page.getByRole('button', { name: /^New Game$/ }).click();
-    await expect(page.getByText('End Game?')).toBeVisible();
+    // The scoring screen utility row has an "End Game" button that opens the
+    // confirm modal, which itself has an "End Game" confirm button — `.first()`
+    // targets the row button.
+    await page
+      .getByRole('button', { name: /^End Game$/ })
+      .first()
+      .click();
+    await expect(page.getByRole('heading', { name: 'End Game?' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'End Game' }).click();
+    // Now the modal is open, click the modal's confirm button (last match).
+    await page
+      .getByRole('button', { name: /^End Game$/ })
+      .last()
+      .click();
 
-    await expect(page.getByRole('heading', { name: 'Game Statistics' })).toBeVisible();
-    // Post-game, the user navigates to a fresh game via the nav tab
-    await page.getByRole('navigation').getByRole('button', { name: 'New Game' }).click();
+    // Stats screen uses a "Game Result" kicker + contextual headline rather
+    // than a generic "Game Statistics" heading.
+    await expect(page.getByTestId('game-summary-panel')).toBeVisible();
+    // The nav bar is hidden for unauthenticated users; the Stats screen has
+    // its own "Start New Game" CTA below the summary panel.
+    await page.getByRole('button', { name: /Start New Game/i }).click();
 
     await expect(page.getByRole('heading', { name: 'New Game' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Start Game' })).toBeVisible();

--- a/tests/e2e/game-history-enhancements.spec.ts
+++ b/tests/e2e/game-history-enhancements.spec.ts
@@ -56,8 +56,8 @@ test.describe('Game history enhancements', () => {
     await page.goto('/');
     await page.evaluate(() => window.dispatchEvent(new Event('switchToHistory')));
 
-    await expect(page.getByRole('heading', { name: /Game History \(3\)/ })).toBeVisible();
-    await expect(page.getByText('Showing 3 of 3 games')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Game History' })).toBeVisible();
+    await expect(page.getByText('(3)')).toBeVisible();
     await expect(page.getByRole('button', { name: /View Trends/ })).toBeVisible();
 
     await page.getByLabel('From', { exact: true }).fill('2026-04-01');
@@ -72,7 +72,7 @@ test.describe('Game history enhancements', () => {
     await page.getByLabel('Opponent', { exact: true }).fill('');
     await page.getByLabel('Sort', { exact: true }).selectOption('total-score-desc');
 
-    const visibleGameCards = page.locator('.cursor-pointer').filter({
+    const visibleGameCards = page.getByTestId('game-list-item').filter({
       hasText: /Alice|Bob|Charlie/,
     });
     await expect(visibleGameCards.first()).toContainText('Charlie');


### PR DESCRIPTION
## Summary

Brings the e2e fixtures back in sync with the post-#108/#109/#110 UI. The same two specs have failed on each of the last three PRs merged into main; the issue is stale assertions, not a regression. After these changes the targeted suites are green locally.

## What changed

`tests/e2e/game-history-enhancements.spec.ts`
- Heading no longer embeds the count — the kicker pattern (#108) split `(3)` into a sibling `<span>`. Assert the heading and the count separately.
- `Showing X of Y games` only renders while a filter is narrowing the list (#109). Drop the unfiltered assertion; the filtered case further down already covers it.
- Game cards are now `<button data-testid="game-list-item">`, not divs with `.cursor-pointer`. Switch the sort assertion's locator.

`tests/e2e/game-flows.spec.ts` ("completes a game and returns to setup after viewing statistics")
- Scoring screen utility row's `New Game` was renamed to `End Game` in the design refresh (#109). Both the row and the modal expose an `End Game` button — use `.first()`/`.last()` to disambiguate. Mirrors the `getAllByRole` pattern already used in `src/__tests__/app.end-game.integration.test.tsx`.
- `getByText('End Game?')` matched both the modal heading and a parent containing the row pill plus the modal heading; constrain to the heading role to satisfy strict mode.
- The `Game Statistics` `<h2>` was replaced with a contextual `X wins` / `Game tied` headline under a `Game Result` kicker — assert the `game-summary-panel` testid instead.
- The post-game nav tab is hidden for unauthenticated users (which the e2e suite is). Use the Stats screen's own `Start New Game` CTA to return to setup.

## Test plan

- [x] `npx playwright test tests/e2e/game-flows.spec.ts tests/e2e/game-history-enhancements.spec.ts` — 6/6 passing locally
- [ ] Full CI check on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)