### PR TITLE
💄 Remove Shot Clock picker from New Game; keep limitless turn timer

### DIFF
--- a/src/__tests__/error-recovery.integration.test.tsx
+++ b/src/__tests__/error-recovery.integration.test.tsx
@@ -58,7 +58,7 @@ describe('Error Recovery Integration Tests', () => {
         ['Alice', 'Bob'],
         { Alice: 100, Bob: 100 },
         0,
-        15,
+        null,
       );
     });
   });
@@ -109,7 +109,7 @@ describe('Error Recovery Integration Tests', () => {
         ['Alice', 'Bob'],
         { Alice: 100, Bob: 100 },
         0,
-        15,
+        null,
       );
     });
   });
@@ -145,7 +145,7 @@ describe('Error Recovery Integration Tests', () => {
         ['Alice', 'Bob'],
         { Alice: 100, Bob: 100 },
         0,
-        15,
+        null,
       );
     });
 
@@ -195,7 +195,7 @@ describe('Error Recovery Integration Tests', () => {
         ['Alice', 'Bob'],
         { Alice: 50, Bob: 100 },
         0,
-        15,
+        null,
       );
     });
   });
@@ -243,7 +243,7 @@ describe('Error Recovery Integration Tests', () => {
         ['Alice', 'Bob'],
         { Alice: 100, Bob: 100 },
         1, // Player 2 (index 1) should be breaking
-        15,
+        null,
       );
     });
   });

--- a/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
@@ -269,7 +269,7 @@ describe('GameScoring integration', () => {
     expect(screen.queryByTestId('match-timer-bot')).not.toBeInTheDocument();
   });
 
-  test('shows shot clock disabled state when the clock is turned off', async () => {
+  test('shows running turn timer without limit badge when shot clock is off', async () => {
     render(
       <GameScoring
         players={['Alice', 'Bob']}
@@ -292,9 +292,8 @@ describe('GameScoring integration', () => {
       />,
     );
 
-    expect(await screen.findByTestId('turn-timer-disabled')).toHaveTextContent(
-      'Shot Clock Off',
-    );
+    expect(await screen.findByTestId('turn-timer')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Shot clock set to/i)).not.toBeInTheDocument();
   });
 
   test('shows the configured shot clock duration when enabled', async () => {

--- a/src/components/GameSetup.test.tsx
+++ b/src/components/GameSetup.test.tsx
@@ -45,10 +45,6 @@ describe('GameSetup Component', () => {
     // Check default values for numeric inputs
     const targetScoreInputs = screen.getAllByDisplayValue(100);
     expect(targetScoreInputs).toHaveLength(2);
-    expect(screen.getByRole('button', { name: '15s' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
 
     // Check breaking player selection (Player 1 should be default)
     const player1Card = screen.getByRole('button', {
@@ -155,7 +151,7 @@ describe('GameSetup Component', () => {
       ['Player One', 'Player Two'],
       { 'Player One': 100, 'Player Two': 75 },
       0, // Player 1 (index 0) is breaking
-      15,
+      null,
     );
   });
 
@@ -184,27 +180,7 @@ describe('GameSetup Component', () => {
       ['Player One', 'Player Two'],
       { 'Player One': 100, 'Player Two': 100 },
       1, // Player 2 (index 1) is breaking
-      15,
-    );
-  });
-
-  test('passes the selected shot clock into startGame', async () => {
-    render(
-      <GamePersistProvider>
-        <GameSetup startGame={mockStartGame} />
-      </GamePersistProvider>,
-    );
-
-    await userEvent.type(screen.getByLabelText('Player 1 name'), 'Player One');
-    await userEvent.type(screen.getByLabelText('Player 2 name'), 'Player Two');
-    await userEvent.click(screen.getByRole('button', { name: '35s' }));
-    fireEvent.click(screen.getByRole('button', { name: /Start Game/i }));
-
-    expect(mockStartGame).toHaveBeenCalledWith(
-      ['Player One', 'Player Two'],
-      { 'Player One': 100, 'Player Two': 100 },
-      0,
-      35,
+      null,
     );
   });
 
@@ -212,7 +188,6 @@ describe('GameSetup Component', () => {
     const lastPlayers = ['John', 'Mike'];
     const lastPlayerTargetScores = { John: 125, Mike: 100 };
     const lastBreakingPlayerId = 1; // Mike was breaking
-    const lastShotClockSeconds = 35;
 
     render(
       <GamePersistProvider>
@@ -221,7 +196,6 @@ describe('GameSetup Component', () => {
           lastPlayers={lastPlayers}
           lastPlayerTargetScores={lastPlayerTargetScores}
           lastBreakingPlayerId={lastBreakingPlayerId}
-          lastShotClockSeconds={lastShotClockSeconds}
         />
       </GamePersistProvider>,
     );
@@ -245,11 +219,6 @@ describe('GameSetup Component', () => {
       name: /Player 1 - tap to select/i,
     });
     expect(player1Card).toHaveAttribute('aria-pressed', 'false');
-
-    expect(screen.getByRole('button', { name: '35s' })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
   });
 
   test('target score inputs work correctly', async () => {

--- a/src/components/GameSetup.tsx
+++ b/src/components/GameSetup.tsx
@@ -3,8 +3,6 @@ import React, { useState, useEffect } from 'react';
 import {
   DEFAULT_PLAYER1_TARGET,
   DEFAULT_PLAYER2_TARGET,
-  DEFAULT_SHOT_CLOCK_SECONDS,
-  SHOT_CLOCK_PRESET_SECONDS,
 } from '../constants/gameSettings';
 import { useGamePersist } from '../context/GamePersistContext';
 import { type GameSetupProps } from '../types/game';
@@ -16,7 +14,6 @@ const GameSetup: React.FC<GameSetupProps> = ({
   lastPlayers,
   lastPlayerTargetScores,
   lastBreakingPlayerId,
-  lastShotClockSeconds,
 }) => {
   const { clearGameState } = useGamePersist();
   const [player1, setPlayer1] = useState('');
@@ -24,9 +21,6 @@ const GameSetup: React.FC<GameSetupProps> = ({
   const [player1TargetScore, setPlayer1TargetScore] = useState(DEFAULT_PLAYER1_TARGET);
   const [player2TargetScore, setPlayer2TargetScore] = useState(DEFAULT_PLAYER2_TARGET);
   const [breakingPlayerId, setBreakingPlayerId] = useState<number>(0);
-  const [shotClockSeconds, setShotClockSeconds] = useState<number | null>(
-    DEFAULT_SHOT_CLOCK_SECONDS,
-  );
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -49,11 +43,7 @@ const GameSetup: React.FC<GameSetupProps> = ({
     if (lastBreakingPlayerId !== undefined) {
       setBreakingPlayerId(lastBreakingPlayerId);
     }
-
-    if (lastShotClockSeconds !== undefined) {
-      setShotClockSeconds(lastShotClockSeconds);
-    }
-  }, [lastPlayers, lastPlayerTargetScores, lastBreakingPlayerId, lastShotClockSeconds]);
+  }, [lastPlayers, lastPlayerTargetScores, lastBreakingPlayerId]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,18 +63,13 @@ const GameSetup: React.FC<GameSetupProps> = ({
       return;
     }
 
-    if (shotClockSeconds !== null && shotClockSeconds <= 0) {
-      setError('Shot clock must be greater than 0 seconds');
-      return;
-    }
-
     const playerTargetScores: Record<string, number> = {
       [player1]: player1TargetScore,
       [player2]: player2TargetScore,
     };
 
     clearGameState();
-    startGame([player1, player2], playerTargetScores, breakingPlayerId, shotClockSeconds);
+    startGame([player1, player2], playerTargetScores, breakingPlayerId, null);
   };
 
   return (
@@ -131,47 +116,6 @@ const GameSetup: React.FC<GameSetupProps> = ({
           isBreaking={breakingPlayerId === 1}
           onSelectBreaking={() => setBreakingPlayerId(1)}
         />
-
-        <section className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-md border border-gray-100 dark:border-gray-700">
-          <div className="mb-3">
-            <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
-              Shot Clock
-            </h2>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              Choose the per-turn timer for this match.
-            </p>
-          </div>
-
-          <div className="grid grid-cols-4 gap-2">
-            <button
-              type="button"
-              onClick={() => setShotClockSeconds(null)}
-              aria-pressed={shotClockSeconds === null}
-              className={`rounded-xl px-3 py-2 text-sm font-medium transition-colors ${
-                shotClockSeconds === null
-                  ? 'bg-blue-600 text-white shadow-sm'
-                  : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
-              }`}
-            >
-              Off
-            </button>
-            {SHOT_CLOCK_PRESET_SECONDS.map((preset) => (
-              <button
-                key={preset}
-                type="button"
-                onClick={() => setShotClockSeconds(preset)}
-                aria-pressed={shotClockSeconds === preset}
-                className={`rounded-xl px-3 py-2 text-sm font-medium transition-colors ${
-                  shotClockSeconds === preset
-                    ? 'bg-blue-600 text-white shadow-sm'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
-                }`}
-              >
-                {preset}s
-              </button>
-            ))}
-          </div>
-        </section>
 
         {/* Start Game Button */}
         <button

--- a/src/components/TurnTimer.tsx
+++ b/src/components/TurnTimer.tsx
@@ -41,42 +41,16 @@ export const TurnTimer: React.FC<TurnTimerProps> = memo(
       }
     }, [startTime, isRunning]);
 
-    if (shotClockSeconds === null) {
-      return (
-        <div
-          className="flex items-center gap-1 sm:gap-2 bg-slate-100 dark:bg-slate-800 px-2 py-1 sm:px-3 sm:py-2 rounded-lg"
-          data-testid="turn-timer-disabled"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-3.5 w-3.5 sm:h-4 sm:w-4 text-slate-500 dark:text-slate-300"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M6 18L18 6M6 6l12 12"
-            />
-          </svg>
-          <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
-            Shot Clock Off
-          </span>
-        </div>
-      );
-    }
-
     const minutes = Math.floor(elapsedSeconds / 60);
     const seconds = elapsedSeconds % 60;
     const elapsedTime =
       `${minutes.toString().padStart(2, '0')}:` +
       `${seconds.toString().padStart(2, '0')}`;
-    const isOverLimit = elapsedSeconds >= shotClockSeconds;
+    const hasLimit = shotClockSeconds !== null;
+    const isOverLimit = hasLimit && elapsedSeconds >= shotClockSeconds;
     const isApproaching =
-      !isOverLimit && elapsedSeconds >= Math.floor(shotClockSeconds * 0.75);
-    // Three states: neutral (in budget), approaching (>=75%), over.
+      hasLimit && !isOverLimit && elapsedSeconds >= Math.floor(shotClockSeconds * 0.75);
+    // Three states: neutral (no limit, or in budget), approaching (>=75%), over.
     const containerClasses = isOverLimit
       ? 'bg-red-100 dark:bg-red-900'
       : isApproaching
@@ -120,12 +94,14 @@ export const TurnTimer: React.FC<TurnTimerProps> = memo(
         <span className={`text-sm sm:text-lg font-mono font-bold ${timeClasses}`}>
           {elapsedTime}
         </span>
-        <span
-          className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide sm:text-xs ${badgeClasses}`}
-          aria-label={`Shot clock set to ${shotClockSeconds} seconds`}
-        >
-          {shotClockSeconds}s
-        </span>
+        {hasLimit && (
+          <span
+            className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide sm:text-xs ${badgeClasses}`}
+            aria-label={`Shot clock set to ${shotClockSeconds} seconds`}
+          >
+            {shotClockSeconds}s
+          </span>
+        )}
       </div>
     );
   },

--- a/src/constants/gameSettings.ts
+++ b/src/constants/gameSettings.ts
@@ -15,7 +15,6 @@ export const DEFAULT_PLAYER1_TARGET = 100;
 export const DEFAULT_PLAYER2_TARGET = 100;
 
 /**
- * Shot clock defaults and common tournament presets
+ * Shot clock defaults
  */
 export const DEFAULT_SHOT_CLOCK_SECONDS = 15;
-export const SHOT_CLOCK_PRESET_SECONDS = [15, 25, 30, 35, 45, 60] as const;


### PR DESCRIPTION
## Summary
- Removed the Shot Clock picker block on the New Game screen — every new game now starts with no shot-clock limit
- Turn timer still ticks during gameplay so you can see how long someone's been at the table; the `15s` countdown badge and amber/red warning colors are skipped when there's no limit
- Updated affected unit/integration tests; dropped now-unused `SHOT_CLOCK_PRESET_SECONDS` constant

## Test plan
- [x] `npm run build`
- [x] Targeted test runs: `GameSetup.test.tsx`, `GameScoring.integration.test.tsx`, `error-recovery.integration.test.tsx`, `useGameSettings.test.ts`, `App.start-game.test.tsx`, `game-scoring.integration.test.tsx`, `GameScoring.consecutiveFoul.integration.test.tsx`
- [x] Full test suite via pre-push hook (234/234 passing)
- [ ] Manual smoke test on preview deploy: New Game screen has no Shot Clock section; in-game shows neutral elapsed timer with no countdown badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)