### PR TITLE
🚀 Add TestFlight + Google Play deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -61,21 +63,21 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
-        
+
     - name: Install dependencies
       run: npm ci
-      
+
     - name: Build project
       env:
         VITE_SUPABASE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
@@ -150,7 +152,7 @@ jobs:
   notify:
     needs: [test, deploy]
     runs-on: ubuntu-latest
-    if: always() && github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: always() && (github.ref == 'refs/heads/main' || github.event_name == 'release' || github.event_name == 'workflow_dispatch')
     
     steps:
     - name: Deployment Summary

--- a/.github/workflows/google-play.yml
+++ b/.github/workflows/google-play.yml
@@ -1,0 +1,148 @@
+name: Deploy to Google Play
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: '22'
+  JAVA_VERSION: '21'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          VITE_SUPABASE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+        run: VITE_BASE=./ npm run build
+
+      - name: Sync Capacitor
+        run: npx cap sync android
+
+      - name: Resolve version metadata
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo v1.0.0)"
+          fi
+          echo "ANDROID_VERSION_NAME=${VERSION#v}" >> $GITHUB_ENV
+          echo "ANDROID_VERSION_CODE=${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 --decode > $RUNNER_TEMP/release.jks
+          echo "KEYSTORE_PATH=$RUNNER_TEMP/release.jks" >> $GITHUB_ENV
+
+      - name: Build signed AAB
+        env:
+          KEYSTORE_PATH: ${{ env.KEYSTORE_PATH }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          cd android
+          ./gradlew bundleRelease
+
+      - name: Upload to Play Store internal track
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          npm install --no-save googleapis@latest
+          cat > upload-aab.mjs << 'NODESCRIPT'
+          import { google } from 'googleapis'
+          import { readFileSync } from 'node:fs'
+
+          const PACKAGE = 'net.rbios.runcount'
+          const TRACK = 'internal'
+          const AAB_PATH = 'android/app/build/outputs/bundle/release/app-release.aab'
+          const VERSION_NAME = process.env.ANDROID_VERSION_NAME
+
+          const rawJson = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON || ''
+          if (!rawJson) {
+            console.error('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON is empty')
+            process.exit(1)
+          }
+          const credentials = JSON.parse(rawJson)
+          const auth = new google.auth.GoogleAuth({
+            credentials,
+            scopes: ['https://www.googleapis.com/auth/androidpublisher'],
+          })
+          const publisher = google.androidpublisher({ version: 'v3', auth })
+
+          try {
+            const edit = await publisher.edits.insert({ packageName: PACKAGE })
+            const editId = edit.data.id
+            const upload = await publisher.edits.bundles.upload({
+              packageName: PACKAGE,
+              editId,
+              media: {
+                mimeType: 'application/octet-stream',
+                body: readFileSync(AAB_PATH),
+              },
+            })
+            const versionCode = upload.data.versionCode
+            await publisher.edits.tracks.update({
+              packageName: PACKAGE,
+              editId,
+              track: TRACK,
+              requestBody: {
+                track: TRACK,
+                releases: [
+                  {
+                    name: VERSION_NAME,
+                    status: 'draft',
+                    versionCodes: [String(versionCode)],
+                  },
+                ],
+              },
+            })
+            await publisher.edits.commit({ packageName: PACKAGE, editId })
+            console.log(`Uploaded versionCode ${versionCode} to ${TRACK} track`)
+          } catch (e) {
+            console.error('Upload failed', e.code || e.response?.status, e.message)
+            if (e.response?.data) console.error(JSON.stringify(e.response.data, null, 2))
+            process.exit(1)
+          }
+          NODESCRIPT
+          node upload-aab.mjs
+
+      - name: Upload AAB artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-aab
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: warn

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -7,14 +7,18 @@ on:
 
 env:
   NODE_VERSION: '22'
+  APPLE_TEAM_ID: U4L88W98BS
 
 jobs:
   build-and-upload:
-    runs-on: macos-15
+    runs-on: [self-hosted, macOS]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -26,26 +30,26 @@ jobs:
         run: npm ci
 
       - name: Build web app
-        run: VITE_BASE=./ npm run build
         env:
           VITE_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           VITE_SUPABASE_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+        run: VITE_BASE=./ npm run build
 
       - name: Sync Capacitor
         run: npx cap sync ios
 
-      - name: Set build number from run
+      - name: Resolve version metadata
         run: |
           BUILD_NUMBER=${{ github.run_number }}
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" ios/App/App/Info.plist
-
-      - name: Set marketing version from release tag
-        if: github.event_name == 'release'
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+          else
+            VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo v1.0.0)"
+          fi
           VERSION="${VERSION#v}"
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" ios/App/App/Info.plist
+          echo "MARKETING_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install App Store Connect API key
         run: |
@@ -73,11 +77,13 @@ jobs:
             -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }} \
             -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }} \
             CODE_SIGN_STYLE=Automatic \
-            DEVELOPMENT_TEAM=U4L88W98BS
+            DEVELOPMENT_TEAM=${{ env.APPLE_TEAM_ID }} \
+            MARKETING_VERSION="$MARKETING_VERSION" \
+            CURRENT_PROJECT_VERSION="$BUILD_NUMBER"
 
       - name: Export and upload to App Store Connect
         run: |
-          cat > $RUNNER_TEMP/ExportOptions.plist << 'PLIST'
+          cat > $RUNNER_TEMP/ExportOptions.plist << PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -85,7 +91,7 @@ jobs:
             <key>method</key>
             <string>app-store-connect</string>
             <key>teamID</key>
-            <string>U4L88W98BS</string>
+            <string>${{ env.APPLE_TEAM_ID }}</string>
             <key>uploadSymbols</key>
             <true/>
             <key>destination</key>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,129 @@
+# Releasing RunCount
+
+Publishing a `vX.Y.Z` GitHub Release fans out three deployments in parallel:
+
+| Target       | Output                                     |
+| ------------ | ------------------------------------------ |
+| Web          | S3 + CloudFront (`runcount.rbios.net`)     |
+| iOS / iPadOS | TestFlight                                 |
+| Android      | Google Play internal testing track (draft) |
+
+End-to-end takes ~10 minutes from `gh release create` to all three artifacts uploaded.
+
+## Cutting a release
+
+```sh
+gh release create vX.Y.Z --generate-notes
+```
+
+Or via the GitHub UI: Releases → Draft a new release → tag `vX.Y.Z` → Publish.
+
+The three workflows fire in parallel:
+
+- [deploy.yml](.github/workflows/deploy.yml) — web → S3 + CloudFront (~3 min)
+- [google-play.yml](.github/workflows/google-play.yml) — Android → Play internal track (~4 min on `ubuntu-latest`)
+- [testflight.yml](.github/workflows/testflight.yml) — iOS → TestFlight (~7 min on the self-hosted Mac runner, plus Apple post-processing)
+
+`workflow_dispatch` works the same way — versions are derived from the latest tag via `git describe`.
+
+## Versioning
+
+- **Marketing version** comes from the release tag (e.g. `v1.2.3` → `1.2.3`).
+- **Build number / `versionCode`** comes from `${{ github.run_number }}` — monotonically increasing per repo run, satisfies App Store Connect and Play Store uniqueness rules.
+- iOS `Info.plist` uses `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)` placeholders; the workflow passes both as `xcodebuild archive` build settings rather than editing Info.plist (which would be clobbered at archive time).
+- Android `build.gradle` reads `ANDROID_VERSION_NAME` / `ANDROID_VERSION_CODE` from the environment, with sane defaults for local builds.
+
+## One-time setup (already done for runcount)
+
+- Capacitor 8 scaffolded with `appId: net.rbios.runcount`, iOS + Android projects added.
+- iOS: `TARGETED_DEVICE_FAMILY = "1,2"` (iPhone + iPad), `IPHONEOS_DEPLOYMENT_TARGET = 15.0`, `DEVELOPMENT_TEAM = U4L88W98BS`, `ITSAppUsesNonExemptEncryption = false` in `Info.plist`.
+- Capacitor configured with `ios.packageManager = "SPM"`.
+
+## One-time setup still required
+
+Before the first end-to-end release works, complete these (full instructions in [Mobile Distribution Setup](https://github.com/rbios/) SOP):
+
+### Self-hosted Mac runner (percolator)
+
+- Already registered for this repo with labels `[self-hosted, macOS]`.
+- Xcode 26+ installed with iOS platform support (`xcodebuild -downloadPlatform iOS`).
+- Running as a launchd service; the LaunchAgent plist has `SessionCreate` removed so codesign can reach the login keychain.
+
+### Apple side
+
+- Apple Developer Program membership active.
+- Both agreements accepted: PLA (developer portal) and Paid/Free Apps Agreement (App Store Connect → Business).
+- App Store Connect API key (Admin role) — `.p8` + Key ID + Issuer ID.
+- App record exists in App Store Connect under bundle id `net.rbios.runcount`.
+
+### Google side
+
+- Google Play Developer account verified (identity + mobile device).
+- App created in Play Console under package `net.rbios.runcount`.
+- Google Cloud project with Play Developer API enabled; service account JSON key created.
+- Service account invited to Play Console with: View app information, Release apps to testing tracks, Manage testing tracks and edit tester lists.
+- **First AAB must be uploaded manually** (Play API rejects the first upload). Dispatch `google-play.yml` once, download the `app-release-aab` artifact, upload via Play Console → Internal testing → Create new release. Opt into App Signing by Google Play here. Future API uploads will then succeed.
+
+### Android signing keystore
+
+- Generated locally with `keytool -genkey -v -keystore runcount-release.jks ...`. Stored in `~/private_keys/` (or equivalent), `chmod 600`, backed up to a password manager with both passwords. **Losing this keystore means losing the ability to update RunCount on Play Store forever.**
+
+### GitHub secrets
+
+```
+APP_STORE_CONNECT_API_KEY           # contents of the .p8 file
+APP_STORE_CONNECT_API_KEY_ID        # 10-char ID
+APP_STORE_CONNECT_API_ISSUER_ID     # UUID
+
+KEYSTORE_BASE64                     # base64 of runcount-release.jks
+KEYSTORE_PASSWORD
+KEY_ALIAS
+KEY_PASSWORD
+GOOGLE_PLAY_SERVICE_ACCOUNT_JSON    # the service-account JSON contents
+
+# already present for the web deploy
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+SUPABASE_URL
+SUPABASE_ANON_KEY
+VITE_SENTRY_DSN
+```
+
+Sanity check: `gh secret list` should show fresh timestamps for all of the above.
+
+## Testing the install
+
+### iOS (TestFlight)
+
+1. Add testers in App Store Connect → TestFlight → Internal Testing → Testers (e.g. `ryan.mette@gmail.com`).
+2. Install the TestFlight app on iOS device, sign in with that Apple ID.
+3. Build appears within ~10 min of upload (after Apple processing).
+
+### Android (Internal testing track)
+
+1. Play Console → RunCount → Test and release → Internal testing → **Testers** tab → create email list with `ryan.mette@gmail.com`, **check the box to apply it to the test**.
+2. Copy the opt-in URL from "How testers join your test".
+3. Open URL on Android device (Play Store app, not Play Console app).
+4. Tap **Become a tester** → **Download it on Google Play**.
+
+Internal-test apps are not findable via Play Store search. Deep link:
+
+```
+https://play.google.com/store/apps/details?id=net.rbios.runcount
+```
+
+While the app is still in Play Console "draft" state, the upload script uses `status: 'draft'`. Once the app is past draft (privacy policy, content rating, screenshots, etc. completed), flip to `status: 'completed'` in [.github/workflows/google-play.yml](.github/workflows/google-play.yml) so internal-tester rollout happens automatically.
+
+## Common gotchas
+
+See the upstream SOP for the full table — the highlights:
+
+| Symptom                                                                 | Fix                                                                                                                                      |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| TestFlight build shows wrong version                                    | Already fixed: workflow passes `MARKETING_VERSION=` / `CURRENT_PROJECT_VERSION=` on `xcodebuild archive` rather than editing Info.plist. |
+| "Missing Compliance" blocks TestFlight build from reaching testers      | Already fixed: `ITSAppUsesNonExemptEncryption=false` in Info.plist.                                                                      |
+| `error: PLA Update available` during archive                            | Apple updated the PLA — re-accept at developer.apple.com/account.                                                                        |
+| `403 FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED` during upload    | Re-accept the Paid/Free Apps Agreement in App Store Connect → Business.                                                                  |
+| `codesign ... errSecInternalComponent` only when runner runs as service | Already addressed: percolator's LaunchAgent plist has `SessionCreate` stripped so codesign can reach the unlocked login keychain.        |
+| Play upload fails with "Service account JSON length: 0 chars"           | `gh secret set < file` silently failed — re-pipe and verify `gh secret list` timestamp.                                                  |
+| Tester opt-in URL says "App not available"                              | Tester not on the email list, list not checkboxed on the release, or release still in Draft.                                             |

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -53,9 +53,9 @@ captures/
 .idea/navEditor.xml
 
 # Keystore files
-# Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
+keystore.properties
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'com.android.application'
 
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "net.rbios.runcount"
     compileSdk = rootProject.ext.compileSdkVersion
@@ -7,8 +13,8 @@ android {
         applicationId "net.rbios.runcount"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode System.getenv("ANDROID_VERSION_CODE") ? System.getenv("ANDROID_VERSION_CODE").toInteger() : 1
+        versionName System.getenv("ANDROID_VERSION_NAME") ?: "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
@@ -16,10 +22,24 @@ android {
             ignoreAssetsPattern = '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            def storeFilePath = keystoreProperties.getProperty("storeFile") ?: System.getenv("KEYSTORE_PATH")
+            if (storeFilePath) {
+                storeFile file(storeFilePath)
+                storePassword keystoreProperties.getProperty("storePassword") ?: System.getenv("KEYSTORE_PASSWORD")
+                keyAlias keystoreProperties.getProperty("keyAlias") ?: System.getenv("KEY_ALIAS")
+                keyPassword keystoreProperties.getProperty("keyPassword") ?: System.getenv("KEY_PASSWORD")
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (signingConfigs.release.storeFile) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -2,6 +2,7 @@ App/build
 App/Pods
 App/output
 App/App/public
+App/SPM
 DerivedData
 xcuserdata
 


### PR DESCRIPTION
## Summary

- Follow the [Mobile Distribution Setup](https://github.com/rbios/) playbook (validated against tiny-tanks v1.0.2) so that publishing a `vX.Y.Z` GitHub Release fans out to S3, TestFlight, and Play Store internal testing in parallel.
- New [.github/workflows/google-play.yml](.github/workflows/google-play.yml) — signed AAB build on `ubuntu-latest`, inline `googleapis` upload to internal track (status: draft).
- Refresh [.github/workflows/testflight.yml](.github/workflows/testflight.yml) — switch to self-hosted Mac runner (percolator), pass \`MARKETING_VERSION\`/\`CURRENT_PROJECT_VERSION\` directly on \`xcodebuild archive\` (Info.plist edits get clobbered at archive time), derive version from git tag with \`workflow_dispatch\` fallback.
- [.github/workflows/deploy.yml](.github/workflows/deploy.yml) — add \`release: published\` trigger so the web build refreshes on tag too.
- [android/app/build.gradle](android/app/build.gradle) — env-driven \`versionCode\`/\`versionName\` and release signing config from \`keystore.properties\` or env vars.
- Ignore \`App/SPM\`, \`*.jks\`, \`*.keystore\`, \`keystore.properties\` so we never commit signing material.
- New [RELEASING.md](RELEASING.md) — project-specific release playbook.

## Test plan

- [ ] CI green on this PR (lint + unit tests + web build)
- [ ] After merge: percolator registered on this repo with labels \`[self-hosted, macOS]\`
- [ ] Apple secrets set: \`APP_STORE_CONNECT_API_KEY\`, \`APP_STORE_CONNECT_API_KEY_ID\`, \`APP_STORE_CONNECT_API_ISSUER_ID\`
- [ ] Android secrets set: \`KEYSTORE_BASE64\`, \`KEYSTORE_PASSWORD\`, \`KEY_ALIAS\`, \`KEY_PASSWORD\`, \`GOOGLE_PLAY_SERVICE_ACCOUNT_JSON\`
- [ ] App records exist in App Store Connect and Play Console under \`net.rbios.runcount\`
- [ ] First AAB manually seeded to Play Console internal track (Play API rejects the first upload)
- [ ] \`gh release create v0.1.0-rc1 --prerelease\` fires all three workflows; iOS lands in TestFlight and Android lands as a draft on the internal track

🤖 Generated with [Claude Code](https://claude.com/claude-code)