### PR TITLE
🐛 Strip prerelease suffix from iOS MARKETING_VERSION

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -49,6 +49,9 @@ jobs:
             VERSION="$(git describe --tags --abbrev=0 2>/dev/null || echo v1.0.0)"
           fi
           VERSION="${VERSION#v}"
+          # Strip prerelease suffix (e.g. 0.1.0-rc1 -> 0.1.0). Apple's
+          # CFBundleShortVersionString must be 1-3 period-separated integers.
+          VERSION="${VERSION%%-*}"
           echo "MARKETING_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Install App Store Connect API key


### PR DESCRIPTION
## Summary

Apple's \`CFBundleShortVersionString\` must be composed of 1-3 period-separated integers. A release tag like \`v0.1.0-rc1\` previously leaked through as \`MARKETING_VERSION=0.1.0-rc1\` and \`xcodebuild archive\` rejected it. Trim everything from the first \`-\` onward so the iOS marketing version becomes \`0.1.0\` while Android keeps the full \`versionName\` (\`-rc1\` etc. is fine in Play Store metadata).

## Test plan

- [ ] Cut a \`vX.Y.Z-rcN\` prerelease tag; \`testflight.yml\` MARKETING_VERSION resolves to \`X.Y.Z\` (suffix stripped) and the archive step succeeds.
- [ ] Cut a \`vX.Y.Z\` plain tag; MARKETING_VERSION still resolves to \`X.Y.Z\` (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)