### PR TITLE
✅ Add scoring simulation coverage

### DIFF
--- a/src/components/GameScoring/hooks/__tests__/useGameActions.simulation.test.tsx
+++ b/src/components/GameScoring/hooks/__tests__/useGameActions.simulation.test.tsx
@@ -1,0 +1,272 @@
+import { useRef, useState } from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { useGameActions } from '../useGameActions';
+
+import type { GameAction, Player } from '../../../../types/game';
+import type { Mock } from 'vitest';
+
+interface SimulationState {
+  actions: GameAction[];
+  activePlayerIndex: number;
+  alertMessage: string;
+  ballsOnTable: number;
+  currentInning: number;
+  currentRun: number;
+  gameWinner: Player | null;
+  isEndGameModalOpen: boolean;
+  isUndoEnabled: boolean;
+  matchEndTime: Date | null;
+  playerData: Player[];
+  playerNeedsReBreak: number | null;
+  turnStartTime: Date | null;
+}
+
+interface SimulationHarness {
+  handleAddScore: ReturnType<typeof useGameActions>['handleAddScore'];
+  handleAddFoul: ReturnType<typeof useGameActions>['handleAddFoul'];
+  handleAddSafety: ReturnType<typeof useGameActions>['handleAddSafety'];
+  handleAddMiss: ReturnType<typeof useGameActions>['handleAddMiss'];
+  saveGameToSupabase: Mock;
+  state: SimulationState;
+}
+
+type SimulatedActionType = 'score' | 'foul' | 'safety' | 'miss';
+
+const targetScore = 40;
+
+const createPlayers = (): Player[] => [
+  {
+    id: 0,
+    name: 'Alice',
+    score: 0,
+    innings: 1,
+    highRun: 0,
+    fouls: 0,
+    consecutiveFouls: 0,
+    safeties: 0,
+    missedShots: 0,
+    targetScore,
+  },
+  {
+    id: 1,
+    name: 'Bob',
+    score: 0,
+    innings: 0,
+    highRun: 0,
+    fouls: 0,
+    consecutiveFouls: 0,
+    safeties: 0,
+    missedShots: 0,
+    targetScore,
+  },
+];
+
+const createRandom = (seed: number) => {
+  let state = seed;
+
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+};
+
+const randomInt = (random: () => number, min: number, max: number) =>
+  Math.floor(random() * (max - min + 1)) + min;
+
+const chooseActionType = (
+  random: () => number,
+  state: SimulationState,
+): SimulatedActionType => {
+  const activePlayer = state.playerData[state.activePlayerIndex];
+
+  if (state.actions.length === 0 || state.playerNeedsReBreak === activePlayer.id) {
+    return random() < 0.7 ? 'score' : 'miss';
+  }
+
+  const roll = random();
+  if (roll < 0.62) return 'score';
+  if (roll < 0.76) return 'safety';
+  if (roll < 0.9) return 'miss';
+  return 'foul';
+};
+
+const chooseBallsRemaining = (
+  random: () => number,
+  ballsOnTable: number,
+  preferredPocketed?: number,
+) => {
+  const pocketed = preferredPocketed ?? randomInt(random, 0, Math.max(0, ballsOnTable));
+
+  return Math.max(0, ballsOnTable - Math.min(pocketed, ballsOnTable));
+};
+
+const useSimulationHarness = (): SimulationHarness => {
+  const [playerData, setPlayerData] = useState<Player[]>(() => createPlayers());
+  const [activePlayerIndex, setActivePlayerIndex] = useState(0);
+  const [currentRun, setCurrentRun] = useState(0);
+  const [ballsOnTable, setBallsOnTable] = useState(15);
+  const [actions, setActions] = useState<GameAction[]>([]);
+  const [currentInning, setCurrentInning] = useState(1);
+  const [gameWinner, setGameWinner] = useState<Player | null>(null);
+  const [isEndGameModalOpen, setShowEndGameModal] = useState(false);
+  const [playerNeedsReBreak, setPlayerNeedsReBreak] = useState<number | null>(null);
+  const [alertMessage, setAlertMessage] = useState('');
+  const [isUndoEnabled, setIsUndoEnabled] = useState(false);
+  const [matchEndTime, setMatchEndTime] = useState<Date | null>(null);
+  const [turnStartTime, setTurnStartTime] = useState<Date | null>(new Date());
+  const saveGameToSupabase = useRef(vi.fn()).current;
+
+  const handlers = useGameActions({
+    playerData,
+    activePlayerIndex,
+    currentRun,
+    ballsOnTable,
+    actions,
+    gameId: 'simulation-game',
+    currentInning,
+    saveGameToSupabase,
+    setPlayerData,
+    setActions,
+    setBallsOnTable,
+    setCurrentRun,
+    setActivePlayerIndex,
+    setTurnStartTime,
+    setCurrentInning,
+    setGameWinner,
+    setShowEndGameModal,
+    setPlayerNeedsReBreak,
+    setShowAlertModal: vi.fn(),
+    setAlertMessage,
+    setIsUndoEnabled,
+    playerNeedsReBreak,
+    setMatchEndTime,
+  });
+
+  return {
+    ...handlers,
+    saveGameToSupabase,
+    state: {
+      actions,
+      activePlayerIndex,
+      alertMessage,
+      ballsOnTable,
+      currentInning,
+      currentRun,
+      gameWinner,
+      isEndGameModalOpen,
+      isUndoEnabled,
+      matchEndTime,
+      playerData,
+      playerNeedsReBreak,
+      turnStartTime,
+    },
+  };
+};
+
+const assertSimulationInvariants = (harness: SimulationHarness) => {
+  const { state } = harness;
+  const playerIds = new Set(state.playerData.map((player) => player.id));
+
+  expect(state.activePlayerIndex).toBeGreaterThanOrEqual(0);
+  expect(state.activePlayerIndex).toBeLessThan(state.playerData.length);
+  expect(state.ballsOnTable).toBeGreaterThanOrEqual(1);
+  expect(state.ballsOnTable).toBeLessThanOrEqual(15);
+  expect(state.currentInning).toBeGreaterThanOrEqual(1);
+  expect(state.currentRun).toBeGreaterThanOrEqual(0);
+  expect(harness.saveGameToSupabase).toHaveBeenCalledTimes(state.actions.length);
+
+  state.actions.forEach((action) => {
+    expect(playerIds.has(action.playerId)).toBe(true);
+    expect(action.ballsOnTable).toBeGreaterThanOrEqual(0);
+    expect(action.ballsOnTable).toBeLessThanOrEqual(15);
+  });
+
+  state.playerData.forEach((player) => {
+    expect(player.innings).toBeGreaterThanOrEqual(0);
+    expect(player.highRun).toBeGreaterThanOrEqual(0);
+    expect(player.fouls).toBe(
+      state.actions.filter(
+        (action) => action.playerId === player.id && action.type === 'foul',
+      ).length,
+    );
+    expect(player.safeties).toBe(
+      state.actions.filter(
+        (action) => action.playerId === player.id && action.type === 'safety',
+      ).length,
+    );
+    expect(player.missedShots).toBe(
+      state.actions.filter(
+        (action) => action.playerId === player.id && action.type === 'miss',
+      ).length,
+    );
+    expect(player.consecutiveFouls).toBeGreaterThanOrEqual(0);
+    expect(player.consecutiveFouls).toBeLessThanOrEqual(2);
+  });
+
+  if (state.gameWinner) {
+    expect(state.gameWinner.score).toBeGreaterThanOrEqual(state.gameWinner.targetScore);
+    expect(state.isEndGameModalOpen).toBe(true);
+    expect(state.matchEndTime).toBeInstanceOf(Date);
+
+    const lastSaveCall = harness.saveGameToSupabase.mock.lastCall;
+    expect(lastSaveCall).toBeDefined();
+    expect(lastSaveCall?.[3]).toBe(true);
+    expect(lastSaveCall?.[4]).toBe(state.gameWinner.id);
+  } else {
+    expect(state.playerData.every((player) => player.score < player.targetScore)).toBe(
+      true,
+    );
+  }
+};
+
+describe('useGameActions generated simulations', () => {
+  test('simulates 100 deterministic games through the real action handlers', () => {
+    const gameCount = 100;
+
+    for (let gameIndex = 0; gameIndex < gameCount; gameIndex += 1) {
+      const random = createRandom(gameIndex + 1);
+      const { result } = renderHook(() => useSimulationHarness());
+
+      for (let actionIndex = 0; actionIndex < 160; actionIndex += 1) {
+        if (result.current.state.gameWinner) break;
+
+        const activePlayer =
+          result.current.state.playerData[result.current.state.activePlayerIndex];
+        const pointsNeeded = activePlayer.targetScore - activePlayer.score;
+        const canWinWithScore =
+          pointsNeeded > 0 && pointsNeeded <= result.current.state.ballsOnTable;
+        const actionType = canWinWithScore
+          ? 'score'
+          : chooseActionType(random, result.current.state);
+        const ballsRemaining = chooseBallsRemaining(
+          random,
+          result.current.state.ballsOnTable,
+          canWinWithScore ? pointsNeeded : undefined,
+        );
+
+        act(() => {
+          if (actionType === 'score') {
+            result.current.handleAddScore(0, ballsRemaining);
+          } else if (actionType === 'foul') {
+            result.current.handleAddFoul(ballsRemaining);
+          } else if (actionType === 'safety') {
+            result.current.handleAddSafety(ballsRemaining);
+          } else {
+            result.current.handleAddMiss(ballsRemaining);
+          }
+        });
+
+        assertSimulationInvariants(result.current);
+      }
+
+      expect(
+        result.current.state.gameWinner,
+        `game ${gameIndex + 1} should complete within the action budget`,
+      ).not.toBeNull();
+      assertSimulationInvariants(result.current);
+    }
+  });
+});

--- a/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
+++ b/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
@@ -148,6 +148,22 @@ describe('useGameActions', () => {
     expect(players[0].consecutiveFouls).toBe(0); // reset fouls
   });
 
+  test('handleAddScore triggers game end when player reaches target score', () => {
+    const { result, players, mocks } = setup();
+    players[0].score = 9;
+
+    act(() => {
+      result.current.handleAddScore(1, 14);
+    });
+
+    expect(players[0].score).toBe(10);
+    expect(mocks.setGameWinner).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Alice' }),
+    );
+    expect(mocks.setShowEndGameModal).toHaveBeenCalledWith(true);
+    expect(mocks.setMatchEndTime).toHaveBeenCalledWith(expect.any(Date));
+  });
+
   test('handleAddFoul applies default break foul penalty (-2 points)', () => {
     const { result, players } = setup();
 

--- a/src/components/GameScoring/hooks/useGameActions.ts
+++ b/src/components/GameScoring/hooks/useGameActions.ts
@@ -102,7 +102,23 @@ export const useGameActions = ({
     }
 
     setPlayerData(updatedPlayerData);
-    saveGameToSupabase(gameId, updatedPlayerData, [...actions, newAction], false, null);
+
+    const playerTargetScore = updatedPlayerData[activePlayerIndex].targetScore;
+    if (updatedPlayerData[activePlayerIndex].score >= playerTargetScore) {
+      const winner = { ...updatedPlayerData[activePlayerIndex] };
+      setGameWinner(winner);
+      setMatchEndTime(new Date());
+      setShowEndGameModal(true);
+      saveGameToSupabase(
+        gameId,
+        updatedPlayerData,
+        [...actions, newAction],
+        true,
+        winner.id,
+      );
+    } else {
+      saveGameToSupabase(gameId, updatedPlayerData, [...actions, newAction], false, null);
+    }
 
     return { needsBOTInput: false };
   };

--- a/tests/e2e/game-flows.spec.ts
+++ b/tests/e2e/game-flows.spec.ts
@@ -35,6 +35,36 @@ test.describe('Straight pool core flows', () => {
     await expect(page.getByTestId('player-score-1')).toHaveText('0');
   });
 
+  test('automatically completes the game when a scoring action reaches target', async ({
+    page,
+  }) => {
+    await startNewGame(page, { playerOneTarget: 14, playerTwoTarget: 30 });
+
+    await completeRack(page, 1);
+
+    await expect(page.getByRole('heading', { name: 'Congratulations!' })).toBeVisible();
+    await expect(page.getByText('Alice Wins!')).toBeVisible();
+    await expect(page.getByTestId('player-score-0')).toHaveText('14');
+
+    const completedGame = await page.evaluate(() => {
+      const historyKey = Object.keys(localStorage).find((key) =>
+        key.startsWith('runcount_game_'),
+      );
+      const storedHistory = historyKey ? localStorage.getItem(historyKey) : null;
+
+      return {
+        activeGame: localStorage.getItem('runcount_active_game'),
+        history: storedHistory ? JSON.parse(storedHistory) : null,
+      };
+    });
+
+    expect(completedGame.activeGame).toBeNull();
+    expect(completedGame.history).toMatchObject({
+      completed: true,
+      winner_id: 0,
+    });
+  });
+
   test('applies break and standard foul penalties with appropriate UI prompts', async ({
     page,
   }) => {
@@ -75,7 +105,7 @@ test.describe('Straight pool core flows', () => {
   test('completes a game and returns to setup after viewing statistics', async ({
     page,
   }) => {
-    await startNewGame(page, { playerOneTarget: 10, playerTwoTarget: 10 });
+    await startNewGame(page, { playerOneTarget: 30, playerTwoTarget: 30 });
 
     await completeRack(page, 1);
     // The scoring screen utility row has an "End Game" button that opens the


### PR DESCRIPTION
## Summary
- complete games when normal scoring reaches the target score
- add a deterministic 100-game simulation over the scoring action handlers
- add Playwright coverage for score-based automatic completion and completed history persistence

## Tests
- npm run lint
- npm run test
- npm run test:e2e
- npm run build