### PR TITLE
[codex] Add AWS backend foundation (#123)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,13 +4,34 @@
 # legacy REACT_APP_* prefix from the Create React App era is ignored — if
 # you have an old .env using REACT_APP_*, rename the keys here.
 
-# --- Required: Supabase project credentials -------------------------------
+# --- Backend selection -----------------------------------------------------
+# Default is the current Supabase backend. Use "aws" only after deploying the
+# Phase 1 AWS infrastructure and wiring the frontend to the API client.
+VITE_BACKEND=supabase
+
+# --- Current backend: Supabase project credentials -------------------------
 # Get these from your Supabase project dashboard:
 #   Settings → API → Project URL  → VITE_SUPABASE_URL
 #   Settings → API → anon / public → VITE_SUPABASE_KEY
 # The anon key is safe to embed in client bundles (RLS gates actual access).
 VITE_SUPABASE_URL=
 VITE_SUPABASE_KEY=
+
+# --- Future backend: AWS API + Cognito ------------------------------------
+VITE_API_URL=
+VITE_COGNITO_REGION=
+VITE_COGNITO_USER_POOL_ID=
+VITE_COGNITO_CLIENT_ID=
+VITE_COGNITO_DOMAIN=
+VITE_COGNITO_REDIRECT_URI=
+VITE_COGNITO_LOGOUT_URI=
+
+# Optional local AWS-auth development shortcut.
+VITE_AUTH_MOCK=
+VITE_AUTH_MOCK_SUB=
+VITE_AUTH_MOCK_EMAIL=
+VITE_AUTH_MOCK_GIVEN_NAME=
+VITE_AUTH_MOCK_FAMILY_NAME=
 
 # --- Optional: error tracking ---------------------------------------------
 # Leave blank to disable Sentry locally.

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 
 # production
 /build
+/infra/cdk.out
+/infra/node_modules
+/infra/bin/*.js
+/infra/bin/*.d.ts
+/infra/lib/*.js
+/infra/lib/*.d.ts
 
 # playwright artifacts
 /playwright-report

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -145,4 +145,15 @@ export default tseslint.config(
       },
     },
   },
+  {
+    files: ['infra/lambda/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        Buffer: 'readonly',
+        console: 'readonly',
+        crypto: 'readonly',
+        process: 'readonly',
+      },
+    },
+  },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,7 @@ export default tseslint.config(
     languageOptions: {
       sourceType: 'module',
       parserOptions: {
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.json', './infra/tsconfig.json'],
         tsconfigRootDir: __dirname,
       },
     },
@@ -37,7 +37,7 @@ export default tseslint.config(
       },
       'import/resolver': {
         typescript: {
-          project: ['./tsconfig.json'],
+          project: ['./tsconfig.json', './infra/tsconfig.json'],
         },
       },
     },

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,43 @@
+# RunCount Infrastructure
+
+AWS CDK stack for the Supabase replacement work in issue #123.
+
+## Stacks
+
+| Stack                     | Resources                                                |
+| ------------------------- | -------------------------------------------------------- |
+| `RunCount-<env>-Auth`     | Cognito User Pool, Google IdP, hosted domain, web client |
+| `RunCount-<env>-Data`     | DynamoDB games table                                     |
+| `RunCount-<env>-Api`      | API Gateway HTTP API + Lambda handler                    |
+| `RunCount-<env>-Frontend` | S3 + CloudFront static site hosting                      |
+
+## Local Setup
+
+```sh
+cd infra
+npm install
+npm run synth
+```
+
+Required CDK context:
+
+```json
+{
+  "envName": "dev",
+  "googleClientId": "your-client-id.apps.googleusercontent.com",
+  "googleSecretName": "runcount/dev/google-oauth",
+  "callbackUrls": ["http://localhost:5173/auth/callback"],
+  "logoutUrls": ["http://localhost:5173/"],
+  "webOrigins": ["http://localhost:5173"]
+}
+```
+
+Create the Google secret out of band:
+
+```sh
+aws secretsmanager create-secret \
+  --name runcount/dev/google-oauth \
+  --secret-string '{"clientSecret":"..."}'
+```
+
+Phase 1 intentionally excludes public signup/account recovery and realtime sync.

--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { App } from 'aws-cdk-lib';
+
+import { ApiStack } from '../lib/api-stack';
+import { AuthStack } from '../lib/auth-stack';
+import { DataStack } from '../lib/data-stack';
+import { FrontendStack } from '../lib/frontend-stack';
+
+const app = new App();
+
+const envName = app.node.tryGetContext('envName') ?? 'dev';
+if (envName !== 'dev' && envName !== 'prod') {
+  throw new Error('envName must be dev or prod');
+}
+
+const account = app.node.tryGetContext('account') ?? process.env.CDK_DEFAULT_ACCOUNT;
+const region =
+  app.node.tryGetContext('region') ?? process.env.CDK_DEFAULT_REGION ?? 'us-east-1';
+const env = { account, region };
+
+const googleClientId = app.node.tryGetContext('googleClientId');
+const googleSecretName =
+  app.node.tryGetContext('googleSecretName') ?? `runcount/${envName}/google-oauth`;
+const callbackUrls = app.node.tryGetContext('callbackUrls') ?? [
+  'http://localhost:5173/auth/callback',
+];
+const logoutUrls = app.node.tryGetContext('logoutUrls') ?? ['http://localhost:5173/'];
+const webOrigins = app.node.tryGetContext('webOrigins') ?? ['http://localhost:5173'];
+
+if (!googleClientId) {
+  throw new Error('Missing CDK context: googleClientId');
+}
+
+const data = new DataStack(app, `RunCount-${envName}-Data`, {
+  env,
+  envName,
+});
+
+const auth = new AuthStack(app, `RunCount-${envName}-Auth`, {
+  env,
+  envName,
+  googleClientId,
+  googleSecretName,
+  callbackUrls,
+  logoutUrls,
+});
+
+new ApiStack(app, `RunCount-${envName}-Api`, {
+  env,
+  envName,
+  userPool: auth.userPool,
+  userPoolClient: auth.userPoolClient,
+  gamesTable: data.gamesTable,
+  webOrigins,
+});
+
+new FrontendStack(app, `RunCount-${envName}-Frontend`, {
+  env,
+  envName,
+});

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/infra.ts"
+}

--- a/infra/lambda/api/handler.mjs
+++ b/infra/lambda/api/handler.mjs
@@ -1,0 +1,235 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DeleteCommand,
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+const region = process.env.AWS_REGION ?? "us-east-1";
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
+
+function json(statusCode, body) {
+  return {
+    statusCode,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+function noContent() {
+  return { statusCode: 204, headers: {}, body: "" };
+}
+
+function error(statusCode, message) {
+  return json(statusCode, { error: message });
+}
+
+function envConfig() {
+  const gamesTable = process.env.GAMES_TABLE;
+  if (!gamesTable) {
+    throw new Error("GAMES_TABLE must be set");
+  }
+  return { gamesTable };
+}
+
+function userClaimsOf(event) {
+  return (
+    event.requestContext?.authorizer?.jwt?.claims ??
+    event.requestContext?.authorizer?.claims ??
+    {}
+  );
+}
+
+function userSubOf(claims) {
+  const sub = claims?.sub;
+  if (typeof sub !== "string" || !sub) {
+    throw new Error("missing user sub");
+  }
+  return sub;
+}
+
+function gameIdParam(event) {
+  return typeof event.pathParameters?.id === "string"
+    ? event.pathParameters.id
+    : "";
+}
+
+function parseJsonBody(event) {
+  if (!event.body) return null;
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body, "base64").toString("utf8")
+    : event.body;
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function dateEpochOf(value) {
+  const ms = new Date(value ?? Date.now()).getTime();
+  return Number.isFinite(ms) ? ms : Date.now();
+}
+
+function gameFromRow(row) {
+  if (!row) return null;
+  return {
+    id: row.gameId,
+    date: row.date,
+    players: row.players ?? [],
+    actions: row.actions ?? [],
+    completed: !!row.completed,
+    winner_id: row.winner_id ?? null,
+    owner_id: row.userId,
+    deleted: !!row.deleted,
+    startTime: row.startTime,
+    endTime: row.endTime,
+    turnStartTime: row.turnStartTime,
+  };
+}
+
+function rowFromGame(userId, gameId, body) {
+  if (!body || typeof body !== "object") {
+    throw new Error("request body must be a game object");
+  }
+  const date = body.date ?? new Date().toISOString();
+  const now = new Date().toISOString();
+  return {
+    userId,
+    gameId,
+    date,
+    dateEpoch: dateEpochOf(date),
+    players: Array.isArray(body.players) ? body.players : [],
+    actions: Array.isArray(body.actions) ? body.actions : [],
+    completed: !!body.completed,
+    winner_id: body.winner_id ?? null,
+    deleted: !!body.deleted,
+    startTime: body.startTime ?? null,
+    endTime: body.endTime ?? null,
+    turnStartTime: body.turnStartTime ?? null,
+    createdAt: body.createdAt ?? now,
+    updatedAt: now,
+  };
+}
+
+async function listGames(env, userId) {
+  const out = await ddb.send(
+    new QueryCommand({
+      TableName: env.gamesTable,
+      IndexName: "GamesByDate",
+      KeyConditionExpression: "userId = :u",
+      FilterExpression: "attribute_not_exists(deleted) OR deleted = :false",
+      ExpressionAttributeValues: {
+        ":u": userId,
+        ":false": false,
+      },
+      ScanIndexForward: false,
+    }),
+  );
+
+  return { games: (out.Items ?? []).map(gameFromRow).filter(Boolean) };
+}
+
+async function getGame(env, userId, gameId) {
+  if (!gameId) return error(400, "game id is required");
+  const out = await ddb.send(
+    new GetCommand({ TableName: env.gamesTable, Key: { userId, gameId } }),
+  );
+  const game = gameFromRow(out.Item);
+  if (!game || game.deleted) return error(404, "game not found");
+  return { game };
+}
+
+async function putGame(env, userId, gameId, body) {
+  if (!gameId) return error(400, "game id is required");
+  const row = rowFromGame(userId, gameId, body);
+  await ddb.send(new PutCommand({ TableName: env.gamesTable, Item: row }));
+  return { game: gameFromRow(row) };
+}
+
+async function postGame(env, userId, body) {
+  const gameId = typeof body?.id === "string" && body.id ? body.id : crypto.randomUUID();
+  return putGame(env, userId, gameId, body);
+}
+
+async function deleteGame(env, userId, gameId) {
+  if (!gameId) return error(400, "game id is required");
+  const existing = await ddb.send(
+    new GetCommand({ TableName: env.gamesTable, Key: { userId, gameId } }),
+  );
+  if (!existing.Item) return noContent();
+
+  await ddb.send(
+    new PutCommand({
+      TableName: env.gamesTable,
+      Item: {
+        ...existing.Item,
+        deleted: true,
+        updatedAt: new Date().toISOString(),
+      },
+    }),
+  );
+  return noContent();
+}
+
+async function getCurrentUser(env, claims, userId) {
+  const games = await listGames(env, userId);
+  const lastGame = games.games[0] ?? null;
+  return {
+    user: {
+      userId,
+      email: typeof claims.email === "string" ? claims.email : null,
+      givenName: typeof claims.given_name === "string" ? claims.given_name : null,
+      familyName: typeof claims.family_name === "string" ? claims.family_name : null,
+      displayName:
+        typeof claims.name === "string"
+          ? claims.name
+          : typeof claims.email === "string"
+            ? claims.email
+            : "RunCount user",
+    },
+    stats: {
+      totalGames: games.games.length,
+      lastGameDate: lastGame?.date ?? null,
+    },
+  };
+}
+
+async function dispatch(event) {
+  const env = envConfig();
+  const claims = userClaimsOf(event);
+  const userId = userSubOf(claims);
+  const method = event.requestContext?.http?.method ?? "";
+  const routeKey = event.routeKey ?? `${method} ${event.rawPath}`;
+
+  switch (routeKey) {
+    case "GET /users/me":
+      return getCurrentUser(env, claims, userId);
+    case "GET /games":
+      return listGames(env, userId);
+    case "POST /games":
+      return postGame(env, userId, parseJsonBody(event));
+    case "GET /games/{id}":
+      return getGame(env, userId, gameIdParam(event));
+    case "PUT /games/{id}":
+      return putGame(env, userId, gameIdParam(event), parseJsonBody(event));
+    case "DELETE /games/{id}":
+      return deleteGame(env, userId, gameIdParam(event));
+    default:
+      return error(404, `No route for ${routeKey}`);
+  }
+}
+
+export async function handler(event) {
+  try {
+    const result = await dispatch(event);
+    if (result && typeof result.statusCode === "number") return result;
+    return json(200, result);
+  } catch (e) {
+    console.error("api error", e);
+    return error(500, e instanceof Error ? e.message : "Internal server error");
+  }
+}

--- a/infra/lambda/api/handler.mjs
+++ b/infra/lambda/api/handler.mjs
@@ -1,6 +1,5 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
-  DeleteCommand,
   DynamoDBDocumentClient,
   GetCommand,
   PutCommand,
@@ -45,7 +44,7 @@ function userClaimsOf(event) {
 function userSubOf(claims) {
   const sub = claims?.sub;
   if (typeof sub !== "string" || !sub) {
-    throw new Error("missing user sub");
+    return null;
   }
   return sub;
 }
@@ -202,6 +201,8 @@ async function dispatch(event) {
   const env = envConfig();
   const claims = userClaimsOf(event);
   const userId = userSubOf(claims);
+  if (!userId) return error(401, "missing user sub");
+
   const method = event.requestContext?.http?.method ?? "";
   const routeKey = event.routeKey ?? `${method} ${event.rawPath}`;
 

--- a/infra/lambda/api/handler.test.mjs
+++ b/infra/lambda/api/handler.test.mjs
@@ -1,0 +1,112 @@
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { handler } from "./handler.mjs";
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+function eventFor(routeKey, { body, claims, id, method = routeKey.split(" ")[0] } = {}) {
+  return {
+    routeKey,
+    rawPath: routeKey.replace(`${method} `, "").replace("{id}", id ?? ""),
+    pathParameters: id ? { id } : {},
+    requestContext: {
+      http: { method },
+      authorizer: {
+        jwt: {
+          claims: claims ?? {
+            sub: "user-1",
+            email: "player@example.com",
+            name: "Player One",
+          },
+        },
+      },
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  };
+}
+
+function parseBody(response) {
+  return response.body ? JSON.parse(response.body) : null;
+}
+
+describe("AWS API handler", () => {
+  beforeEach(() => {
+    process.env.GAMES_TABLE = "games-test";
+    ddbMock.reset();
+  });
+
+  it("stores games under the authenticated Cognito user, ignoring body ownership", async () => {
+    ddbMock.on(PutCommand).resolves({});
+
+    const response = await handler(
+      eventFor("PUT /games/{id}", {
+        id: "path-game-id",
+        body: {
+          id: "body-game-id",
+          owner_id: "other-user",
+          date: "2026-06-15T00:00:00.000Z",
+          players: [{ id: 0, name: "Alice" }],
+          actions: [],
+          completed: true,
+          winner_id: 0,
+        },
+      }),
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response).game).toMatchObject({
+      id: "path-game-id",
+      owner_id: "user-1",
+      winner_id: 0,
+    });
+
+    const [putCall] = ddbMock.commandCalls(PutCommand);
+    expect(putCall.args[0].input.Item).toMatchObject({
+      userId: "user-1",
+      gameId: "path-game-id",
+      players: [{ id: 0, name: "Alice" }],
+    });
+  });
+
+  it("reads games by authenticated user partition and path game id", async () => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        userId: "user-1",
+        gameId: "game-1",
+        date: "2026-06-15T00:00:00.000Z",
+        players: [],
+        actions: [],
+        completed: false,
+      },
+    });
+
+    const response = await handler(eventFor("GET /games/{id}", { id: "game-1" }));
+
+    expect(response.statusCode).toBe(200);
+    expect(parseBody(response).game).toMatchObject({
+      id: "game-1",
+      owner_id: "user-1",
+      deleted: false,
+    });
+
+    const [getCall] = ddbMock.commandCalls(GetCommand);
+    expect(getCall.args[0].input.Key).toEqual({
+      userId: "user-1",
+      gameId: "game-1",
+    });
+  });
+
+  it("returns 401 when the authorizer claims do not include a sub", async () => {
+    const response = await handler(
+      eventFor("GET /games", {
+        claims: { email: "player@example.com" },
+      }),
+    );
+
+    expect(response.statusCode).toBe(401);
+    expect(parseBody(response)).toEqual({ error: "missing user sub" });
+    expect(ddbMock.calls()).toHaveLength(0);
+  });
+});

--- a/infra/lib/api-stack.ts
+++ b/infra/lib/api-stack.ts
@@ -1,0 +1,105 @@
+import * as path from 'node:path';
+
+import { CfnOutput, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { CorsHttpMethod, HttpApi, HttpMethod } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpUserPoolAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import { type UserPool, type UserPoolClient } from 'aws-cdk-lib/aws-cognito';
+import { type Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction, OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { type Construct } from 'constructs';
+
+export interface ApiStackProps extends StackProps {
+  envName: 'dev' | 'prod';
+  userPool: UserPool;
+  userPoolClient: UserPoolClient;
+  gamesTable: Table;
+  webOrigins: string[];
+}
+
+export class ApiStack extends Stack {
+  readonly apiHandlerFn: NodejsFunction;
+  readonly httpApi: HttpApi;
+
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
+    super(scope, id, props);
+
+    const logGroup = new LogGroup(this, 'ApiHandlerFnLogs', {
+      retention: RetentionDays.ONE_MONTH,
+      removalPolicy:
+        props.envName === 'dev' ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+    });
+
+    this.apiHandlerFn = new NodejsFunction(this, 'ApiHandlerFn', {
+      description: 'Authenticated RunCount API routes for games and profile stats.',
+      entry: path.join(__dirname, '..', 'lambda', 'api', 'handler.mjs'),
+      depsLockFilePath: path.join(__dirname, '..', 'package-lock.json'),
+      projectRoot: path.join(__dirname, '..'),
+      handler: 'handler',
+      runtime: Runtime.NODEJS_22_X,
+      architecture: Architecture.ARM_64,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      bundling: {
+        format: OutputFormat.ESM,
+        target: 'node22',
+        externalModules: ['@aws-sdk/*'],
+        minify: false,
+        sourceMap: true,
+      },
+      environment: {
+        GAMES_TABLE: props.gamesTable.tableName,
+        NODE_OPTIONS: '--enable-source-maps',
+      },
+      logGroup,
+    });
+
+    props.gamesTable.grantReadWriteData(this.apiHandlerFn);
+
+    this.httpApi = new HttpApi(this, 'HttpApi', {
+      corsPreflight: {
+        allowOrigins: props.webOrigins,
+        allowMethods: [
+          CorsHttpMethod.GET,
+          CorsHttpMethod.POST,
+          CorsHttpMethod.PUT,
+          CorsHttpMethod.DELETE,
+          CorsHttpMethod.OPTIONS,
+        ],
+        allowHeaders: ['Authorization', 'Content-Type'],
+        maxAge: Duration.days(10),
+      },
+    });
+
+    const authorizer = new HttpUserPoolAuthorizer('UserPoolAuthorizer', props.userPool, {
+      userPoolClients: [props.userPoolClient],
+    });
+
+    const integration = new HttpLambdaIntegration(
+      'ApiHandlerIntegration',
+      this.apiHandlerFn,
+    );
+
+    const routes: Array<{ path: string; methods: HttpMethod[] }> = [
+      { path: '/games', methods: [HttpMethod.GET, HttpMethod.POST] },
+      {
+        path: '/games/{id}',
+        methods: [HttpMethod.GET, HttpMethod.PUT, HttpMethod.DELETE],
+      },
+      { path: '/users/me', methods: [HttpMethod.GET] },
+    ];
+
+    for (const route of routes) {
+      this.httpApi.addRoutes({
+        path: route.path,
+        methods: route.methods,
+        integration,
+        authorizer,
+      });
+    }
+
+    new CfnOutput(this, 'ApiUrl', { value: this.httpApi.apiEndpoint });
+  }
+}

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -1,0 +1,100 @@
+import {
+  CfnOutput,
+  Duration,
+  RemovalPolicy,
+  SecretValue,
+  Stack,
+  type StackProps,
+} from 'aws-cdk-lib';
+import {
+  AccountRecovery,
+  OAuthScope,
+  ProviderAttribute,
+  UserPool,
+  UserPoolClient,
+  UserPoolClientIdentityProvider,
+  UserPoolDomain,
+  UserPoolIdentityProviderGoogle,
+} from 'aws-cdk-lib/aws-cognito';
+import { type Construct } from 'constructs';
+
+export interface AuthStackProps extends StackProps {
+  envName: 'dev' | 'prod';
+  googleClientId: string;
+  googleSecretName: string;
+  callbackUrls: string[];
+  logoutUrls: string[];
+}
+
+export class AuthStack extends Stack {
+  readonly userPool: UserPool;
+  readonly userPoolClient: UserPoolClient;
+  readonly userPoolDomain: UserPoolDomain;
+
+  constructor(scope: Construct, id: string, props: AuthStackProps) {
+    super(scope, id, props);
+
+    const isDev = props.envName === 'dev';
+
+    this.userPool = new UserPool(this, 'UserPool', {
+      userPoolName: `runcount-${props.envName}`,
+      selfSignUpEnabled: false,
+      signInAliases: { email: true },
+      autoVerify: { email: true },
+      standardAttributes: {
+        email: { required: true, mutable: true },
+        givenName: { required: false, mutable: true },
+        familyName: { required: false, mutable: true },
+      },
+      accountRecovery: AccountRecovery.EMAIL_ONLY,
+      removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+    });
+
+    const googleIdp = new UserPoolIdentityProviderGoogle(this, 'GoogleIdp', {
+      userPool: this.userPool,
+      clientId: props.googleClientId,
+      clientSecretValue: SecretValue.secretsManager(props.googleSecretName, {
+        jsonField: 'clientSecret',
+      }),
+      scopes: ['profile', 'email', 'openid'],
+      attributeMapping: {
+        email: ProviderAttribute.GOOGLE_EMAIL,
+        givenName: ProviderAttribute.GOOGLE_GIVEN_NAME,
+        familyName: ProviderAttribute.GOOGLE_FAMILY_NAME,
+      },
+    });
+
+    this.userPoolDomain = new UserPoolDomain(this, 'UserPoolDomain', {
+      userPool: this.userPool,
+      cognitoDomain: {
+        domainPrefix: `runcount-${props.envName}-${this.account.slice(-6)}`,
+      },
+    });
+
+    this.userPoolClient = new UserPoolClient(this, 'WebClient', {
+      userPool: this.userPool,
+      userPoolClientName: `runcount-${props.envName}-web`,
+      generateSecret: false,
+      supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
+      oAuth: {
+        flows: { authorizationCodeGrant: true },
+        scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],
+        callbackUrls: props.callbackUrls,
+        logoutUrls: props.logoutUrls,
+      },
+      accessTokenValidity: Duration.hours(1),
+      idTokenValidity: Duration.hours(1),
+      refreshTokenValidity: Duration.days(30),
+    });
+
+    this.userPoolClient.node.addDependency(googleIdp);
+
+    new CfnOutput(this, 'UserPoolId', { value: this.userPool.userPoolId });
+    new CfnOutput(this, 'UserPoolClientId', {
+      value: this.userPoolClient.userPoolClientId,
+    });
+    new CfnOutput(this, 'UserPoolDomainUrl', {
+      value: `https://${this.userPoolDomain.domainName}.auth.${this.region}.amazoncognito.com`,
+    });
+  }
+}

--- a/infra/lib/data-stack.ts
+++ b/infra/lib/data-stack.ts
@@ -1,0 +1,42 @@
+import { RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import {
+  AttributeType,
+  BillingMode,
+  ProjectionType,
+  Table,
+  TableEncryption,
+} from 'aws-cdk-lib/aws-dynamodb';
+import { type Construct } from 'constructs';
+
+export interface DataStackProps extends StackProps {
+  envName: 'dev' | 'prod';
+}
+
+export class DataStack extends Stack {
+  readonly gamesTable: Table;
+
+  constructor(scope: Construct, id: string, props: DataStackProps) {
+    super(scope, id, props);
+
+    const isDev = props.envName === 'dev';
+
+    this.gamesTable = new Table(this, 'Games', {
+      tableName: `runcount-${props.envName}-games`,
+      partitionKey: { name: 'userId', type: AttributeType.STRING },
+      sortKey: { name: 'gameId', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      encryption: TableEncryption.AWS_MANAGED,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: !isDev,
+      },
+      removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+    });
+
+    this.gamesTable.addGlobalSecondaryIndex({
+      indexName: 'GamesByDate',
+      partitionKey: { name: 'userId', type: AttributeType.STRING },
+      sortKey: { name: 'dateEpoch', type: AttributeType.NUMBER },
+      projectionType: ProjectionType.ALL,
+    });
+  }
+}

--- a/infra/lib/frontend-stack.ts
+++ b/infra/lib/frontend-stack.ts
@@ -1,0 +1,54 @@
+import { CfnOutput, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import {
+  Distribution,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from 'aws-cdk-lib/aws-cloudfront';
+import { S3StaticWebsiteOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import { BlockPublicAccess, Bucket, BucketAccessControl } from 'aws-cdk-lib/aws-s3';
+import { type Construct } from 'constructs';
+
+export interface FrontendStackProps extends StackProps {
+  envName: 'dev' | 'prod';
+}
+
+export class FrontendStack extends Stack {
+  readonly siteBucket: Bucket;
+  readonly distribution: Distribution;
+
+  constructor(scope: Construct, id: string, props: FrontendStackProps) {
+    super(scope, id, props);
+
+    const isDev = props.envName === 'dev';
+
+    this.siteBucket = new Bucket(this, 'SiteBucket', {
+      bucketName: `runcount-${props.envName}-site-${this.account}`,
+      websiteIndexDocument: 'index.html',
+      websiteErrorDocument: 'index.html',
+      publicReadAccess: true,
+      blockPublicAccess: new BlockPublicAccess({
+        blockPublicAcls: false,
+        ignorePublicAcls: false,
+        blockPublicPolicy: false,
+        restrictPublicBuckets: false,
+      }),
+      accessControl: BucketAccessControl.PUBLIC_READ,
+      removalPolicy: isDev ? RemovalPolicy.DESTROY : RemovalPolicy.RETAIN,
+      autoDeleteObjects: isDev,
+    });
+
+    this.distribution = new Distribution(this, 'Distribution', {
+      defaultBehavior: {
+        origin: new S3StaticWebsiteOrigin(this.siteBucket),
+        viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      },
+      defaultRootObject: 'index.html',
+      priceClass: PriceClass.PRICE_CLASS_100,
+    });
+
+    new CfnOutput(this, 'SiteBucketName', { value: this.siteBucket.bucketName });
+    new CfnOutput(this, 'DistributionDomainName', {
+      value: this.distribution.distributionDomainName,
+    });
+  }
+}

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -1,0 +1,1165 @@
+{
+  "name": "runcount-infra",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "runcount-infra",
+      "version": "0.1.0",
+      "dependencies": {
+        "aws-cdk-lib": "^2.180.0",
+        "constructs": "^10.4.2"
+      },
+      "bin": {
+        "infra": "bin/infra.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "aws-cdk": "^2.180.0",
+        "esbuild": "^0.28.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.259.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.259.0.tgz",
+      "integrity": "sha512-qcsbyRBZpFMUzx/Nle5vKXFC14Z1VutvAqw6S4Duh3Yj5ZFl4e/RhN2Vg8QmYktxu9l1aF9H5UyF+Xz81qk9gw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.5",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.1",
+        "table": "^6.9.0",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.5",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.20.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -8,6 +8,8 @@
       "name": "runcount-infra",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1068.0",
+        "@aws-sdk/lib-dynamodb": "^3.1068.0",
         "aws-cdk-lib": "^2.180.0",
         "constructs": "^10.4.2"
       },
@@ -17,6 +19,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "aws-cdk": "^2.180.0",
+        "aws-sdk-client-mock": "^4.1.0",
         "esbuild": "^0.28.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.0"
@@ -68,6 +71,438 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1068.0.tgz",
+      "integrity": "sha512-DOMUWnLSFHaRC0EixpWMnrQcQaV08P5rzAUdRTEkx72NaDRF0Q6+3QdtqX8ocyHfySzwMwOE9/vHRmhNvWHl/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.55",
+        "@aws-sdk/dynamodb-codec": "^3.973.20",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
+      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
+      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
+      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
+      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/token-providers": "3.1066.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
+      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.20.tgz",
+      "integrity": "sha512-SFfxiqVgWeIe+RsJJNAMD//2IfehT4bLpGyNJRB0MgHmOIJtdcfMnR1k7KYyaHokSoQVdncVa9O9DIGa4eqcwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.7.tgz",
+      "integrity": "sha512-LkwS3ZOUNL5kHzmz3dDx8lE3HOhZmf2VGjbJ/tMUZJYWWl3J0RJTZM7RFz1MLt06WDVvlShcAjY/RzhYlqLL7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1068.0.tgz",
+      "integrity": "sha512-r3ChLc59RYNDfenMm+7GJ23zKRzTG+b3nAUgHt9XOKOCaJ3c203DzkY/m5yNslAhZ1r0ArxDaecd8rqioDXRuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/util-dynamodb": "^3.996.4",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1068.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.18.tgz",
+      "integrity": "sha512-1vKJt/6MBB/MBMRM3qzCMdW70syJY8u2DH+dq7yCnPn7wVJmyeAzAa/sK1lIbbYh8BVLbM5FspsT4zbe885gOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.7",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
+      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
+      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1066.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
+      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.4.tgz",
+      "integrity": "sha512-Gel6Qiof4NWdtGT548FxoAkmmKmvsEVQYzbtC4RJnwgh9z33gmiYSJOGnKZHvZJWC2SgjS6AKe6DfuGCqU4vdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1064.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -553,6 +988,179 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.7.tgz",
+      "integrity": "sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz",
+      "integrity": "sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
+      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
+      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
+      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.4.tgz",
+      "integrity": "sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -591,6 +1199,23 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -616,6 +1241,18 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -1007,6 +1644,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/constructs": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
@@ -1072,12 +1727,187 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -1123,6 +1953,22 @@
         }
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1150,6 +1996,21 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/infra/package.json
+++ b/infra/package.json
@@ -16,11 +16,14 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "aws-cdk": "^2.180.0",
+    "aws-sdk-client-mock": "^4.1.0",
     "esbuild": "^0.28.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.0"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1068.0",
+    "@aws-sdk/lib-dynamodb": "^3.1068.0",
     "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.4.2"
   }

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "runcount-infra",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "infra": "bin/infra.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy --all",
+    "destroy": "cdk destroy --all"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "aws-cdk": "^2.180.0",
+    "esbuild": "^0.28.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.0"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.180.0",
+    "constructs": "^10.4.2"
+  }
+}

--- a/infra/tsconfig.json
+++ b/infra/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"],
+    "noEmit": true
+  },
+  "exclude": ["cdk.out"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1068.0",
+        "@aws-sdk/lib-dynamodb": "^3.1068.0",
         "@playwright/test": "^1.56.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@types/node": "^22.10.5",
@@ -44,6 +46,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "autoprefixer": "^10.4.20",
+        "aws-sdk-client-mock": "^4.1.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.1",
         "eslint": "^9.39.1",
@@ -121,6 +124,465 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1068.0.tgz",
+      "integrity": "sha512-DOMUWnLSFHaRC0EixpWMnrQcQaV08P5rzAUdRTEkx72NaDRF0Q6+3QdtqX8ocyHfySzwMwOE9/vHRmhNvWHl/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-node": "^3.972.55",
+        "@aws-sdk/dynamodb-codec": "^3.973.20",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.18",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@aws-sdk/xml-builder": "^3.972.29",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz",
+      "integrity": "sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz",
+      "integrity": "sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz",
+      "integrity": "sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.53",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.52",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.52",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz",
+      "integrity": "sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/token-providers": "3.1066.0",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz",
+      "integrity": "sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.20.tgz",
+      "integrity": "sha512-SFfxiqVgWeIe+RsJJNAMD//2IfehT4bLpGyNJRB0MgHmOIJtdcfMnR1k7KYyaHokSoQVdncVa9O9DIGa4eqcwg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.7.tgz",
+      "integrity": "sha512-LkwS3ZOUNL5kHzmz3dDx8lE3HOhZmf2VGjbJ/tMUZJYWWl3J0RJTZM7RFz1MLt06WDVvlShcAjY/RzhYlqLL7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/lib-dynamodb": {
+      "version": "3.1068.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1068.0.tgz",
+      "integrity": "sha512-r3ChLc59RYNDfenMm+7GJ23zKRzTG+b3nAUgHt9XOKOCaJ3c203DzkY/m5yNslAhZ1r0ArxDaecd8rqioDXRuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/util-dynamodb": "^3.996.4",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1068.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.18.tgz",
+      "integrity": "sha512-1vKJt/6MBB/MBMRM3qzCMdW70syJY8u2DH+dq7yCnPn7wVJmyeAzAa/sK1lIbbYh8BVLbM5FspsT4zbe885gOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.7",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz",
+      "integrity": "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.34",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz",
+      "integrity": "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1066.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz",
+      "integrity": "sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.20",
+        "@aws-sdk/types": "^3.973.12",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.12.tgz",
+      "integrity": "sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.996.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.4.tgz",
+      "integrity": "sha512-Gel6Qiof4NWdtGT548FxoAkmmKmvsEVQYzbtC4RJnwgh9z33gmiYSJOGnKZHvZJWC2SgjS6AKe6DfuGCqU4vdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.1064.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz",
+      "integrity": "sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -1789,6 +2251,19 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -2387,6 +2862,47 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@smithery/sdk": {
       "version": "1.7.4",
       "license": "MIT",
@@ -2401,6 +2917,135 @@
         "uuid": "^11.0.3",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.7",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.7.tgz",
+      "integrity": "sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz",
+      "integrity": "sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz",
+      "integrity": "sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz",
+      "integrity": "sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.7.tgz",
+      "integrity": "sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.7",
+        "@smithy/types": "^4.14.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.4",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.4.tgz",
+      "integrity": "sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2768,6 +3413,23 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/slice-ansi": {
       "version": "4.0.0",
@@ -3616,6 +4278,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "license": "MIT"
@@ -3937,6 +4612,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4017,6 +4704,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bplist-parser": {
       "version": "0.3.2",
@@ -5099,6 +5793,16 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -6324,6 +7028,45 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -7926,6 +8669,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -8314,6 +9064,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -8419,6 +9179,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/node-releases": {
@@ -8662,6 +9445,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/okay-error": {
       "version": "1.0.3",
       "license": "MIT"
@@ -8869,6 +9659,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -10360,6 +11166,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -10813,6 +11638,22 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -11294,6 +12135,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-is": {
@@ -12253,6 +13104,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     ]
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.1068.0",
+    "@aws-sdk/lib-dynamodb": "^3.1068.0",
     "@playwright/test": "^1.56.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@types/node": "^22.10.5",
@@ -69,6 +71,7 @@
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.20",
+    "aws-sdk-client-mock": "^4.1.0",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
     "eslint": "^9.39.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { FC } from 'react';
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 import { AwsAuthProvider, useAwsAuth } from './aws-auth/AwsAuthContext';
 import { isAwsBackend } from './aws-auth/config';
@@ -27,10 +27,16 @@ import type { AppUser } from './types/auth';
 
 import './App.css';
 
-// Initialize Supabase client - Replace with your actual Supabase project details
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
 const supabaseKey = import.meta.env.VITE_SUPABASE_KEY || '';
-const supabase = createClient(supabaseUrl, supabaseKey);
+const supabase = isAwsBackend ? null : createClient(supabaseUrl, supabaseKey);
+
+const getSupabaseClient = (): SupabaseClient => {
+  if (!supabase) {
+    throw new Error('Supabase client is only available when VITE_BACKEND is not aws.');
+  }
+  return supabase;
+};
 
 // Main App Component - now just wraps the content with AuthProvider
 const App: FC = () => {
@@ -46,12 +52,7 @@ const App: FC = () => {
               </GamePersistProvider>
             </AwsAuthProvider>
           ) : (
-            <AuthProvider supabase={supabase}>
-              <GamePersistProvider>
-                <SupabaseAppContent />
-                <ErrorBanner />
-              </GamePersistProvider>
-            </AuthProvider>
+            <SupabaseAppProviders />
           )}
         </ErrorEventsBridge>
       </ErrorBoundary>
@@ -59,7 +60,24 @@ const App: FC = () => {
   );
 };
 
-const SupabaseAppContent: FC = () => {
+const SupabaseAppProviders: FC = () => {
+  const supabaseClient = getSupabaseClient();
+
+  return (
+    <AuthProvider supabase={supabaseClient}>
+      <GamePersistProvider>
+        <SupabaseAppContent supabase={supabaseClient} />
+        <ErrorBanner />
+      </GamePersistProvider>
+    </AuthProvider>
+  );
+};
+
+interface SupabaseAppContentProps {
+  supabase: SupabaseClient;
+}
+
+const SupabaseAppContent: FC<SupabaseAppContentProps> = ({ supabase }) => {
   const { user, loading, signOut } = useAuth();
   const backend = useMemo(() => createSupabaseBackend(supabase), []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { FC } from 'react';
 
 import { createClient } from '@supabase/supabase-js';
 
+import { AwsAuthProvider, useAwsAuth } from './aws-auth/AwsAuthContext';
+import { isAwsBackend } from './aws-auth/config';
+import { createAwsBackend } from './backend/awsBackend';
+import { createSupabaseBackend } from './backend/supabaseBackend';
 import { GameRouter } from './components/GameRouter';
 import { Header } from './components/Header';
 import { AuthModal } from './components/modals/AuthModal';
@@ -18,6 +22,9 @@ import { useGameSettings } from './hooks/useGameSettings';
 import { useGameState } from './hooks/useGameState';
 import { useTheme } from './hooks/useTheme';
 
+import type { GameBackend } from './backend/types';
+import type { AppUser } from './types/auth';
+
 import './App.css';
 
 // Initialize Supabase client - Replace with your actual Supabase project details
@@ -31,21 +38,91 @@ const App: FC = () => {
     <ErrorProvider>
       <ErrorBoundary>
         <ErrorEventsBridge>
-          <AuthProvider supabase={supabase}>
-            <GamePersistProvider>
-              <AppContent />
-              <ErrorBanner />
-            </GamePersistProvider>
-          </AuthProvider>
+          {isAwsBackend ? (
+            <AwsAuthProvider>
+              <GamePersistProvider>
+                <AwsAppContent />
+                <ErrorBanner />
+              </GamePersistProvider>
+            </AwsAuthProvider>
+          ) : (
+            <AuthProvider supabase={supabase}>
+              <GamePersistProvider>
+                <SupabaseAppContent />
+                <ErrorBanner />
+              </GamePersistProvider>
+            </AuthProvider>
+          )}
         </ErrorEventsBridge>
       </ErrorBoundary>
     </ErrorProvider>
   );
 };
 
-// The actual app content, using the auth context
-const AppContent: FC = () => {
+const SupabaseAppContent: FC = () => {
   const { user, loading, signOut } = useAuth();
+  const backend = useMemo(() => createSupabaseBackend(supabase), []);
+
+  return (
+    <AppContent
+      user={user}
+      loading={loading}
+      signOut={signOut}
+      backend={backend}
+      renderAuthModal={({ isOpen, gameState, onClose }) => (
+        <AuthModal
+          isOpen={isOpen}
+          gameState={gameState}
+          supabase={supabase}
+          onClose={onClose}
+        />
+      )}
+    />
+  );
+};
+
+const AwsAppContent: FC = () => {
+  const { user, loading, signOut, getIdToken, signIn } = useAwsAuth();
+  const backend = useMemo(() => createAwsBackend(getIdToken), [getIdToken]);
+
+  return (
+    <AppContent
+      user={user}
+      loading={loading}
+      signOut={signOut}
+      backend={backend}
+      renderAuthModal={({ isOpen, gameState, onClose }) => (
+        <AwsAuthModal
+          isOpen={isOpen}
+          gameState={gameState}
+          onClose={onClose}
+          onSignIn={signIn}
+        />
+      )}
+    />
+  );
+};
+
+interface AppContentProps {
+  user: AppUser | null;
+  loading: boolean;
+  signOut: () => Promise<void>;
+  backend: GameBackend;
+  renderAuthModal: (props: {
+    isOpen: boolean;
+    gameState: ReturnType<typeof useGameState>['gameState'];
+    onClose: () => void;
+  }) => React.ReactNode;
+}
+
+// The actual app content, using the selected auth/backend implementation.
+const AppContent: FC<AppContentProps> = ({
+  user,
+  loading,
+  signOut,
+  backend,
+  renderAuthModal,
+}) => {
   const { addError } = useError();
 
   // Custom hooks for feature management
@@ -185,7 +262,7 @@ const AppContent: FC = () => {
       <main className="flex-grow container mx-auto p-4 flex flex-col">
         <GameRouter
           gameState={gameState}
-          supabase={supabase}
+          backend={backend}
           user={user}
           lastPlayers={lastPlayers}
           lastPlayerTargetScores={lastPlayerTargetScores}
@@ -215,20 +292,79 @@ const AppContent: FC = () => {
         />
       </main>
 
-      <AuthModal
-        isOpen={showAuthModal}
-        gameState={gameState}
-        supabase={supabase}
-        onClose={() => setShowAuthModal(false)}
-      />
+      {renderAuthModal({
+        isOpen: showAuthModal,
+        gameState,
+        onClose: () => setShowAuthModal(false),
+      })}
 
       <ProfileModal
         isOpen={showProfileModal}
         user={user}
-        supabase={supabase}
+        backend={backend}
         onClose={() => setShowProfileModal(false)}
         onSignOut={handleSignOut}
       />
+    </div>
+  );
+};
+
+interface AwsAuthModalProps {
+  isOpen: boolean;
+  gameState: ReturnType<typeof useGameState>['gameState'];
+  onClose: () => void;
+  onSignIn: () => Promise<void>;
+}
+
+const AwsAuthModal: FC<AwsAuthModalProps> = ({
+  isOpen,
+  gameState,
+  onClose,
+  onSignIn,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-2 sm:p-4">
+      <div
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm sm:max-w-lg w-full relative"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="aws-auth-modal-title"
+      >
+        <button
+          onClick={onClose}
+          className="absolute top-3 right-3 z-10 w-7 h-7 flex items-center justify-center rounded-full bg-black/30 hover:bg-black/50 text-white transition-colors"
+          aria-label="Close authentication"
+        >
+          ✕
+        </button>
+        <div className="p-5 text-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-700/60 dark:to-gray-700/30 rounded-t-2xl border-b border-gray-200 dark:border-gray-700">
+          <h2 id="aws-auth-modal-title" className="text-xl font-bold dark:text-white">
+            Sign in to RunCount
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Use your Google account to save games to AWS.
+          </p>
+        </div>
+        <div className="p-4 space-y-4">
+          {gameState === 'scoring' || gameState === 'statistics' ? (
+            <div className="p-3 bg-blue-50 dark:bg-blue-900 text-blue-800 dark:text-blue-100 rounded-lg text-sm">
+              Logging in will save your current game to your account.
+            </div>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => void onSignIn()}
+            className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+          >
+            Continue with Google
+          </button>
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+            Signup, password recovery, and account updates are tracked for Phase 2.
+          </p>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/__tests__/game-scoring.integration.test.tsx
+++ b/src/__tests__/game-scoring.integration.test.tsx
@@ -18,15 +18,8 @@ vi.mock('../context/GamePersistContext', () => ({
   }),
 }));
 
-// Mock Supabase
-const mockSupabase = {
-  from: () => ({
-    upsert: vi.fn().mockResolvedValue({ data: null, error: null }),
-    insert: vi.fn().mockResolvedValue({ data: null, error: null }),
-    select: vi.fn().mockReturnThis(),
-    eq: vi.fn().mockReturnThis(),
-    order: vi.fn().mockResolvedValue({ data: [], error: null }),
-  }),
+const mockBackend = {
+  saveGame: vi.fn(async () => undefined),
 };
 
 describe('Game Scoring Integration Tests', () => {
@@ -36,7 +29,7 @@ describe('Game Scoring Integration Tests', () => {
     gameId: null,
     setGameId: vi.fn(),
     finishGame: vi.fn(),
-    supabase: mockSupabase as any,
+    backend: mockBackend as any,
     user: null,
     breakingPlayerId: 0,
     shotClockSeconds: 15,

--- a/src/aws-auth/AwsAuthContext.tsx
+++ b/src/aws-auth/AwsAuthContext.tsx
@@ -1,0 +1,134 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  completeAwsCallback,
+  getFreshIdToken,
+  getStoredAwsSession,
+  getStoredMockUser,
+  getUserFromSession,
+  signOutAws,
+  startAwsSignIn,
+} from './session';
+import { clearTokens, saveTokens } from './tokens';
+
+import type { AppSession, AppUser } from '../types/auth';
+
+interface AwsAuthContextValue {
+  user: AppUser | null;
+  session: AppSession | null;
+  loading: boolean;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+  getIdToken: () => Promise<string | null>;
+  refreshSession: () => Promise<void>;
+}
+
+const AwsAuthContext = createContext<AwsAuthContextValue | undefined>(undefined);
+
+function isAwsCallbackPath(): boolean {
+  const callbackPath = `${import.meta.env.BASE_URL}auth/callback`.replace(/\/+/g, '/');
+  return window.location.pathname === callbackPath;
+}
+
+export const AwsAuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const sessionRef = useRef<AppSession | null>(null);
+  const [user, setUser] = useState<AppUser | null>(null);
+  const [session, setSession] = useState<AppSession | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const applySession = useCallback((nextSession: AppSession | null) => {
+    sessionRef.current = nextSession;
+    setSession(nextSession);
+    if (!nextSession) {
+      clearTokens();
+      setUser(null);
+      return;
+    }
+    saveTokens(nextSession);
+    setUser(getUserFromSession(nextSession));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        if (isAwsCallbackPath()) {
+          const returnTo = await completeAwsCallback();
+          if (!cancelled) {
+            const nextSession = getStoredAwsSession();
+            applySession(nextSession);
+            window.history.replaceState({}, document.title, returnTo);
+          }
+          return;
+        }
+
+        const mockUser = getStoredMockUser();
+        if (mockUser) {
+          setUser(mockUser);
+          return;
+        }
+
+        applySession(getStoredAwsSession());
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applySession]);
+
+  const signIn = useCallback(async () => {
+    await startAwsSignIn();
+  }, []);
+
+  const signOut = useCallback(async () => {
+    signOutAws();
+    applySession(null);
+  }, [applySession]);
+
+  const getIdToken = useCallback(async () => {
+    return getFreshIdToken(sessionRef.current, applySession);
+  }, [applySession]);
+
+  const refreshSession = useCallback(async () => {
+    await getFreshIdToken(sessionRef.current, applySession);
+  }, [applySession]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      session,
+      loading,
+      signIn,
+      signOut,
+      getIdToken,
+      refreshSession,
+    }),
+    [user, session, loading, signIn, signOut, getIdToken, refreshSession],
+  );
+
+  return <AwsAuthContext.Provider value={value}>{children}</AwsAuthContext.Provider>;
+};
+
+export function useAwsAuth(): AwsAuthContextValue {
+  const context = useContext(AwsAuthContext);
+  if (context === undefined) {
+    throw new Error('useAwsAuth must be used within AwsAuthProvider');
+  }
+  return context;
+}

--- a/src/aws-auth/config.ts
+++ b/src/aws-auth/config.ts
@@ -1,0 +1,37 @@
+export const isAwsAuthMock = import.meta.env.VITE_AUTH_MOCK === '1';
+export const isAwsBackend = import.meta.env.VITE_BACKEND === 'aws';
+
+function optionalEnv(name: keyof ImportMetaEnv): string {
+  return (import.meta.env[name] as string | undefined) ?? '';
+}
+
+function requiredEnv(name: keyof ImportMetaEnv): string {
+  const value = optionalEnv(name);
+  if (isAwsAuthMock) return value || `mock-${String(name)}`;
+  if (!isAwsBackend) return value;
+  if (!value) {
+    throw new Error(
+      `Missing required env var: ${String(name)}. Set VITE_BACKEND=aws only after configuring Cognito.`,
+    );
+  }
+  return value;
+}
+
+export const cognitoConfig = {
+  region: requiredEnv('VITE_COGNITO_REGION'),
+  userPoolId: requiredEnv('VITE_COGNITO_USER_POOL_ID'),
+  clientId: requiredEnv('VITE_COGNITO_CLIENT_ID'),
+  domain: requiredEnv('VITE_COGNITO_DOMAIN'),
+  redirectUri: requiredEnv('VITE_COGNITO_REDIRECT_URI'),
+  logoutUri: requiredEnv('VITE_COGNITO_LOGOUT_URI'),
+};
+
+export const mockUser = {
+  id: import.meta.env.VITE_AUTH_MOCK_SUB ?? 'mock-user-1',
+  email: import.meta.env.VITE_AUTH_MOCK_EMAIL ?? 'mock@example.com',
+  created_at: new Date(0).toISOString(),
+  user_metadata: {
+    given_name: import.meta.env.VITE_AUTH_MOCK_GIVEN_NAME ?? 'Mock',
+    family_name: import.meta.env.VITE_AUTH_MOCK_FAMILY_NAME ?? 'User',
+  },
+};

--- a/src/aws-auth/pkce.ts
+++ b/src/aws-auth/pkce.ts
@@ -1,0 +1,25 @@
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return base64Url(bytes);
+}
+
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64Url(bytes);
+}
+
+export async function deriveCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64Url(new Uint8Array(digest));
+}

--- a/src/aws-auth/session.test.ts
+++ b/src/aws-auth/session.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { completeAwsCallback } from './session';
+
+const PKCE_STORAGE_KEY = 'runcount.auth.pkce';
+
+describe('AWS auth session', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    window.history.replaceState({}, '', '/');
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects a callback with a mismatched PKCE state before token exchange', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    sessionStorage.setItem(
+      PKCE_STORAGE_KEY,
+      JSON.stringify({
+        verifier: 'verifier-1',
+        state: 'expected-state',
+        returnTo: '/history',
+      }),
+    );
+    window.history.replaceState({}, '', '/auth/callback?code=abc&state=wrong-state');
+
+    await expect(completeAwsCallback()).rejects.toThrow(
+      'Invalid auth callback. Try signing in again.',
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(PKCE_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/aws-auth/session.ts
+++ b/src/aws-auth/session.ts
@@ -1,0 +1,147 @@
+import { cognitoConfig, isAwsAuthMock, mockUser } from './config';
+import { deriveCodeChallenge, generateCodeVerifier, generateState } from './pkce';
+import {
+  clearTokens,
+  exchangeCodeForTokens,
+  loadTokens,
+  refreshTokens,
+  saveTokens,
+  userFromIdToken,
+} from './tokens';
+
+import type { AppSession, AppUser } from '../types/auth';
+
+const PKCE_STORAGE_KEY = 'runcount.auth.pkce';
+const MOCK_USER_STORAGE_KEY = 'runcount.auth.mock-user';
+
+interface PendingPkce {
+  verifier: string;
+  state: string;
+  returnTo: string;
+}
+
+function stashPkce(pending: PendingPkce): void {
+  sessionStorage.setItem(PKCE_STORAGE_KEY, JSON.stringify(pending));
+}
+
+function takePkce(): PendingPkce | null {
+  const raw = sessionStorage.getItem(PKCE_STORAGE_KEY);
+  if (!raw) return null;
+  sessionStorage.removeItem(PKCE_STORAGE_KEY);
+  try {
+    return JSON.parse(raw) as PendingPkce;
+  } catch {
+    return null;
+  }
+}
+
+export function getStoredAwsSession(): AppSession | null {
+  return loadTokens();
+}
+
+export function getUserFromSession(session: AppSession): AppUser {
+  return userFromIdToken(session.idToken);
+}
+
+export function getStoredMockUser(): AppUser | null {
+  const raw = localStorage.getItem(MOCK_USER_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AppUser;
+  } catch {
+    return null;
+  }
+}
+
+export async function startAwsSignIn(): Promise<void> {
+  if (isAwsAuthMock) {
+    localStorage.setItem(MOCK_USER_STORAGE_KEY, JSON.stringify(mockUser));
+    window.location.reload();
+    return;
+  }
+
+  const verifier = generateCodeVerifier();
+  const challenge = await deriveCodeChallenge(verifier);
+  const state = generateState();
+  const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+  const path = window.location.pathname;
+  const routerPath = base && path.startsWith(base) ? path.slice(base.length) : path;
+
+  stashPkce({
+    verifier,
+    state,
+    returnTo: (routerPath || '/') + window.location.search,
+  });
+
+  const params = new URLSearchParams({
+    client_id: cognitoConfig.clientId,
+    response_type: 'code',
+    scope: 'openid email profile',
+    redirect_uri: cognitoConfig.redirectUri,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    identity_provider: 'Google',
+  });
+
+  window.location.assign(`${cognitoConfig.domain}/oauth2/authorize?${params}`);
+}
+
+export function signOutAws(): void {
+  if (isAwsAuthMock) {
+    localStorage.removeItem(MOCK_USER_STORAGE_KEY);
+    window.location.reload();
+    return;
+  }
+
+  clearTokens();
+  const params = new URLSearchParams({
+    client_id: cognitoConfig.clientId,
+    logout_uri: cognitoConfig.logoutUri,
+  });
+  window.location.assign(`${cognitoConfig.domain}/logout?${params}`);
+}
+
+export async function getFreshIdToken(
+  session: AppSession | null,
+  applySession: (session: AppSession | null) => void,
+): Promise<string | null> {
+  if (!session) return null;
+  if (Date.now() < session.expiresAt) return session.idToken;
+  if (!session.refreshToken) {
+    applySession(null);
+    return null;
+  }
+
+  try {
+    const refreshed = await refreshTokens(session.refreshToken);
+    saveTokens(refreshed);
+    applySession(refreshed);
+    return refreshed.idToken;
+  } catch {
+    clearTokens();
+    applySession(null);
+    return null;
+  }
+}
+
+export async function completeAwsCallback(): Promise<string> {
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get('error');
+  if (error) {
+    throw new Error(`${error}: ${params.get('error_description') ?? 'no description'}`);
+  }
+
+  const code = params.get('code');
+  const state = params.get('state');
+  const pending = takePkce();
+  if (!code || !state || !pending || pending.state !== state) {
+    throw new Error('Invalid auth callback. Try signing in again.');
+  }
+
+  const tokens = await exchangeCodeForTokens(code, pending.verifier);
+  saveTokens(tokens);
+  return pending.returnTo && pending.returnTo !== '/auth/callback'
+    ? pending.returnTo
+    : '/';
+}

--- a/src/aws-auth/tokens.ts
+++ b/src/aws-auth/tokens.ts
@@ -1,0 +1,108 @@
+import { cognitoConfig } from './config';
+
+import type { AppSession, AppUser } from '../types/auth';
+
+const STORAGE_KEY = 'runcount.auth.tokens';
+
+interface CognitoUserClaims {
+  sub: string;
+  email?: string;
+  given_name?: string;
+  family_name?: string;
+  name?: string;
+  iat?: number;
+}
+
+interface TokenResponse {
+  id_token: string;
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+}
+
+function decodeJwt<T = unknown>(token: string): T {
+  const [, payload] = token.split('.');
+  const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(padded)) as T;
+}
+
+function toSession(res: TokenResponse, existingRefresh?: string): AppSession {
+  return {
+    idToken: res.id_token,
+    accessToken: res.access_token,
+    refreshToken: res.refresh_token ?? existingRefresh ?? '',
+    expiresAt: Date.now() + (res.expires_in - 30) * 1000,
+  };
+}
+
+export function loadTokens(): AppSession | null {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as AppSession;
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function saveTokens(session: AppSession): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+}
+
+export function clearTokens(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+export function userFromIdToken(idToken: string): AppUser {
+  const claims = decodeJwt<CognitoUserClaims>(idToken);
+  return {
+    id: claims.sub,
+    email: claims.email,
+    created_at: claims.iat ? new Date(claims.iat * 1000).toISOString() : undefined,
+    user_metadata: {
+      given_name: claims.given_name,
+      family_name: claims.family_name,
+      name: claims.name,
+    },
+  };
+}
+
+export async function exchangeCodeForTokens(
+  code: string,
+  verifier: string,
+): Promise<AppSession> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: cognitoConfig.clientId,
+    code,
+    redirect_uri: cognitoConfig.redirectUri,
+    code_verifier: verifier,
+  });
+
+  const res = await fetch(`${cognitoConfig.domain}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  if (!res.ok) throw new Error(`Token exchange failed: ${res.status}`);
+  return toSession((await res.json()) as TokenResponse);
+}
+
+export async function refreshTokens(refreshToken: string): Promise<AppSession> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: cognitoConfig.clientId,
+    refresh_token: refreshToken,
+  });
+
+  const res = await fetch(`${cognitoConfig.domain}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+
+  if (!res.ok) throw new Error(`Token refresh failed: ${res.status}`);
+  return toSession((await res.json()) as TokenResponse, refreshToken);
+}

--- a/src/backend/awsBackend.ts
+++ b/src/backend/awsBackend.ts
@@ -1,0 +1,40 @@
+import {
+  deleteGame as deleteGameFromApi,
+  getCurrentUser,
+  getGame,
+  listGames,
+  saveGame,
+} from '../lib/awsApiClient';
+
+import type { GameBackend } from './types';
+
+export function createAwsBackend(getIdToken: () => Promise<string | null>): GameBackend {
+  const requireToken = async () => {
+    const token = await getIdToken();
+    if (!token) throw new Error('You must be signed in to use cloud sync.');
+    return token;
+  };
+
+  return {
+    async listGames() {
+      return listGames(await requireToken());
+    },
+
+    async getGame(gameId) {
+      return getGame(gameId, await requireToken());
+    },
+
+    async saveGame(game) {
+      await saveGame(game, await requireToken());
+    },
+
+    async deleteGame(gameId) {
+      await deleteGameFromApi(gameId, await requireToken());
+    },
+
+    async getProfileStats() {
+      const currentUser = await getCurrentUser(await requireToken());
+      return currentUser.stats;
+    },
+  };
+}

--- a/src/backend/supabaseBackend.ts
+++ b/src/backend/supabaseBackend.ts
@@ -1,0 +1,118 @@
+import type { GameBackend } from './types';
+import type { AppUser } from '../types/auth';
+import type { GameData } from '../types/game';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+function validGames(data: unknown): GameData[] {
+  if (!Array.isArray(data)) return [];
+  return data
+    .filter((game) => {
+      if (!game || typeof game !== 'object') return false;
+      const candidate = game as Partial<GameData>;
+      return (
+        !!candidate.id && Array.isArray(candidate.players) && candidate.players.length > 0
+      );
+    })
+    .map((game) => game as unknown as GameData);
+}
+
+export function createSupabaseBackend(supabase: SupabaseClient): GameBackend {
+  return {
+    async listGames(user: AppUser | null) {
+      const query = supabase.from('games').select('*');
+      if (user?.id) query.eq('owner_id', user.id);
+      query.eq('deleted', false);
+      query.order('date', { ascending: false });
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return validGames(data);
+    },
+
+    async getGame(gameId: string) {
+      const { data, error } = await supabase
+        .from('games')
+        .select('*')
+        .eq('id', gameId)
+        .eq('deleted', false)
+        .single();
+      if (error) throw error;
+      return data as unknown as GameData | null;
+    },
+
+    async saveGame(game: GameData, user: AppUser | null) {
+      if (!user) return;
+      const payload = {
+        ...game,
+        owner_id: user.id,
+        deleted: false,
+      };
+      const { error } = await supabase.from('games').upsert(payload);
+      if (error) throw error;
+    },
+
+    async deleteGame(gameId: string) {
+      const { error } = await supabase
+        .from('games')
+        .update({ deleted: true })
+        .eq('id', gameId);
+      if (error) throw error;
+    },
+
+    async getProfileStats(user: AppUser) {
+      const { data, error } = await supabase
+        .from('games')
+        .select('date')
+        .eq('owner_id', user.id)
+        .eq('deleted', false)
+        .order('date', { ascending: false });
+      if (error || !data) {
+        return { totalGames: 0, lastGameDate: null };
+      }
+      return {
+        totalGames: data.length,
+        lastGameDate: data.length > 0 && data[0]?.date ? String(data[0].date) : null,
+      };
+    },
+
+    async updateEmail(email: string) {
+      const { error } = await supabase.auth.updateUser({ email });
+      if (error) throw error;
+    },
+
+    async updatePassword(password: string) {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+    },
+
+    subscribeToGames(user, onChange) {
+      const subscription = supabase
+        .channel('games-changes')
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'games',
+            filter: user?.id ? `owner_id=eq.${user.id}` : undefined,
+          },
+          (payload) => {
+            if (payload.eventType === 'INSERT') {
+              onChange({ type: 'INSERT', game: payload.new as unknown as GameData });
+            } else if (payload.eventType === 'UPDATE') {
+              onChange({ type: 'UPDATE', game: payload.new as unknown as GameData });
+            } else if (payload.eventType === 'DELETE') {
+              onChange({ type: 'DELETE', game: payload.old as unknown as GameData });
+            }
+          },
+        )
+        .subscribe();
+
+      return {
+        unsubscribe: () => {
+          supabase.removeChannel(subscription);
+        },
+      };
+    },
+  };
+}

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -1,0 +1,25 @@
+import type { AppUser } from '../types/auth';
+import type { GameData } from '../types/game';
+
+export interface ProfileStats {
+  totalGames: number;
+  lastGameDate: string | null;
+}
+
+export interface GameSubscription {
+  unsubscribe: () => void;
+}
+
+export interface GameBackend {
+  listGames: (user: AppUser | null) => Promise<GameData[]>;
+  getGame: (gameId: string) => Promise<GameData | null>;
+  saveGame: (game: GameData, user: AppUser | null) => Promise<void>;
+  deleteGame: (gameId: string) => Promise<void>;
+  getProfileStats: (user: AppUser) => Promise<ProfileStats>;
+  updateEmail?: (email: string) => Promise<void>;
+  updatePassword?: (password: string) => Promise<void>;
+  subscribeToGames?: (
+    user: AppUser | null,
+    onChange: (event: { type: 'INSERT' | 'UPDATE' | 'DELETE'; game: GameData }) => void,
+  ) => GameSubscription;
+}

--- a/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
+++ b/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
@@ -4,27 +4,6 @@ import { vi } from 'vitest';
 import { createMockGameData } from '../../../../testing/factories';
 import { useGameHistory } from '../useGameHistory';
 
-const createQuery = (result: unknown) => {
-  const query = {
-    select: vi.fn(() => query),
-    eq: vi.fn(() => query),
-    order: vi.fn(() => query),
-    update: vi.fn(() => query),
-    then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
-  };
-
-  return query;
-};
-
-const createSupabase = (query: ReturnType<typeof createQuery>) => ({
-  from: vi.fn(() => query),
-  channel: vi.fn(() => ({
-    on: vi.fn().mockReturnThis(),
-    subscribe: vi.fn(() => ({ id: 'subscription' })),
-  })),
-  removeChannel: vi.fn(),
-});
-
 describe('useGameHistory', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_DISABLE_SUPABASE_REALTIME', 'true');
@@ -34,48 +13,52 @@ describe('useGameHistory', () => {
     vi.unstubAllEnvs();
   });
 
-  test('loads valid games from Supabase ordered by date', async () => {
+  test('loads valid games from backend', async () => {
     const validGame = createMockGameData({ id: 'valid-game' });
     const invalidGame = { id: 'invalid-game', players: [] };
-    const query = createQuery({ data: [validGame, invalidGame], error: null });
-    const supabase = createSupabase(query);
+    const backend = {
+      listGames: vi.fn().mockResolvedValue([validGame, invalidGame]),
+      deleteGame: vi.fn(),
+    };
 
     const { result } = renderHook(() =>
-      useGameHistory({ supabase: supabase as never, user: null }),
+      useGameHistory({ backend: backend as never, user: null }),
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(supabase.from).toHaveBeenCalledWith('games');
-    expect(query.eq).toHaveBeenCalledWith('deleted', false);
-    expect(query.order).toHaveBeenCalledWith('date', { ascending: false });
+    expect(backend.listGames).toHaveBeenCalledWith(null);
     expect(result.current.games).toEqual([validGame]);
     expect(result.current.error).toBe('');
   });
 
-  test('filters authenticated queries by owner id', async () => {
-    const query = createQuery({ data: [], error: null });
-    const supabase = createSupabase(query);
+  test('passes authenticated user to backend queries', async () => {
+    const backend = {
+      listGames: vi.fn().mockResolvedValue([]),
+      deleteGame: vi.fn(),
+    };
     const user = { id: 'user-1' };
 
     const { result } = renderHook(() =>
       useGameHistory({
-        supabase: supabase as never,
+        backend: backend as never,
         user: user as never,
       }),
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(query.eq).toHaveBeenCalledWith('owner_id', 'user-1');
+    expect(backend.listGames).toHaveBeenCalledWith(user);
   });
 
   test('sets an error when loading games fails', async () => {
-    const query = createQuery({ data: null, error: new Error('load failed') });
-    const supabase = createSupabase(query);
+    const backend = {
+      listGames: vi.fn().mockRejectedValue(new Error('load failed')),
+      deleteGame: vi.fn(),
+    };
 
     const { result } = renderHook(() =>
-      useGameHistory({ supabase: supabase as never, user: null }),
+      useGameHistory({ backend: backend as never, user: null }),
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -86,13 +69,13 @@ describe('useGameHistory', () => {
 
   test('soft deletes a game and removes it from local state', async () => {
     const game = createMockGameData({ id: 'game-to-delete' });
-    const query = createQuery({ data: [game], error: null });
-    const deleteQuery = createQuery({ error: null });
-    const supabase = createSupabase(query);
-    supabase.from.mockReturnValueOnce(query).mockReturnValueOnce(deleteQuery);
+    const backend = {
+      listGames: vi.fn().mockResolvedValue([game]),
+      deleteGame: vi.fn().mockResolvedValue(undefined),
+    };
 
     const { result } = renderHook(() =>
-      useGameHistory({ supabase: supabase as never, user: null }),
+      useGameHistory({ backend: backend as never, user: null }),
     );
 
     await waitFor(() => expect(result.current.games).toHaveLength(1));
@@ -101,8 +84,7 @@ describe('useGameHistory', () => {
       await result.current.deleteGame('game-to-delete');
     });
 
-    expect(deleteQuery.update).toHaveBeenCalledWith({ deleted: true });
-    expect(deleteQuery.eq).toHaveBeenCalledWith('id', 'game-to-delete');
+    expect(backend.deleteGame).toHaveBeenCalledWith('game-to-delete');
     expect(result.current.games).toEqual([]);
   });
 });

--- a/src/components/GameHistory/hooks/useGameHistory.ts
+++ b/src/components/GameHistory/hooks/useGameHistory.ts
@@ -1,15 +1,16 @@
 import { useState, useEffect } from 'react';
 
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
-
 import { type GameData } from '../../../types/game';
 
+import type { GameBackend } from '../../../backend/types';
+import type { AppUser } from '../../../types/auth';
+
 interface UseGameHistoryProps {
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
 }
 
-export const useGameHistory = ({ supabase, user }: UseGameHistoryProps) => {
+export const useGameHistory = ({ backend, user }: UseGameHistoryProps) => {
   const [games, setGames] = useState<GameData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -19,27 +20,7 @@ export const useGameHistory = ({ supabase, user }: UseGameHistoryProps) => {
       try {
         setLoading(true);
 
-        // Simplify the query to just get user's games
-        const query = supabase.from('games').select('*');
-
-        // If user is authenticated, filter by owner
-        if (user?.id) {
-          query.eq('owner_id', user.id);
-        }
-
-        // Filter out deleted games
-        query.eq('deleted', false);
-
-        // Order by date descending
-        query.order('date', { ascending: false });
-
-        // Execute query
-        const { data, error } = await query;
-
-        if (error) {
-          console.error('Error fetching games:', error);
-          throw error;
-        }
+        const data = await backend.listGames(user);
 
         // Type cast and filter out any potentially invalid data
         const validGames = (data || [])
@@ -76,69 +57,38 @@ export const useGameHistory = ({ supabase, user }: UseGameHistoryProps) => {
 
     fetchGames();
 
-    if (import.meta.env.VITE_DISABLE_SUPABASE_REALTIME === 'true') {
+    if (
+      import.meta.env.VITE_DISABLE_SUPABASE_REALTIME === 'true' ||
+      !backend.subscribeToGames
+    ) {
       return undefined;
     }
 
-    // Set up a real-time subscription to the games table
-    const subscription = supabase
-      .channel('games-changes')
-      .on(
-        'postgres_changes',
-        {
-          event: '*',
-          schema: 'public',
-          table: 'games',
-          filter: user?.id ? `owner_id=eq.${user.id}` : undefined,
-        },
-        (payload) => {
-          // Handle different types of changes
-          if (payload.eventType === 'INSERT') {
-            const newGame = payload.new as unknown as GameData;
-            if (!newGame.deleted) {
-              setGames((prevGames) => [newGame, ...prevGames]);
-            }
-          } else if (payload.eventType === 'UPDATE') {
-            const updatedGame = payload.new as unknown as GameData;
-            setGames((prevGames) => {
-              if (updatedGame.deleted) {
-                // If the game was soft-deleted, remove it from the list
-                return prevGames.filter((game) => game.id !== updatedGame.id);
-              } else {
-                // Otherwise, update the game in the list
-                return prevGames.map((game) =>
-                  game.id === updatedGame.id ? updatedGame : game,
-                );
-              }
-            });
-          } else if (payload.eventType === 'DELETE') {
-            const deletedGame = payload.old as unknown as GameData;
-            setGames((prevGames) =>
-              prevGames.filter((game) => game.id !== deletedGame.id),
-            );
+    const subscription = backend.subscribeToGames(user, ({ type, game }) => {
+      if (type === 'INSERT') {
+        if (!game.deleted) {
+          setGames((prevGames) => [game, ...prevGames]);
+        }
+      } else if (type === 'UPDATE') {
+        setGames((prevGames) => {
+          if (game.deleted) {
+            return prevGames.filter((entry) => entry.id !== game.id);
           }
-        },
-      )
-      .subscribe();
+          return prevGames.map((entry) => (entry.id === game.id ? game : entry));
+        });
+      } else if (type === 'DELETE') {
+        setGames((prevGames) => prevGames.filter((entry) => entry.id !== game.id));
+      }
+    });
 
-    // Clean up the subscription when the component unmounts
     return () => {
-      supabase.removeChannel(subscription);
+      subscription.unsubscribe();
     };
-  }, [supabase, user]);
+  }, [backend, user]);
 
   const deleteGame = async (gameId: string) => {
     try {
-      // Soft delete - update game with deleted flag
-      const { error } = await supabase
-        .from('games')
-        .update({ deleted: true })
-        .eq('id', gameId);
-
-      if (error) {
-        console.error('Error soft-deleting game:', error);
-        throw error;
-      }
+      await backend.deleteGame(gameId);
 
       // Update local state
       setGames(games.filter((g) => g.id !== gameId));

--- a/src/components/GameHistory/index.tsx
+++ b/src/components/GameHistory/index.tsx
@@ -17,7 +17,7 @@ import {
 } from './utils/historyEnhancements';
 
 const GameHistory: React.FC<GameHistoryProps> = ({
-  supabase,
+  backend,
   startNewGame,
   user = null,
   viewTrends,
@@ -28,7 +28,7 @@ const GameHistory: React.FC<GameHistoryProps> = ({
   const [sortOption, setSortOption] = useState<HistorySortOption>('date-desc');
 
   const { games, loading, error, deleteGame } = useGameHistory({
-    supabase,
+    backend,
     user,
   });
 

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -7,14 +7,14 @@ import GameSetup from './GameSetup';
 import GameStatistics from './GameStatistics';
 import TrendsPage from './Trends/index';
 
+import type { GameBackend } from '../backend/types';
 import type { GameState } from '../hooks/useGameState';
-import type { User } from '@supabase/supabase-js';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import type { AppUser } from '../types/auth';
 
 interface GameRouterProps {
   gameState: GameState;
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
   // Game setup props
   lastPlayers: string[];
   lastPlayerTargetScores: Record<string, number>;
@@ -57,7 +57,7 @@ interface GameRouterProps {
  */
 export const GameRouter: FC<GameRouterProps> = ({
   gameState,
-  supabase,
+  backend,
   user,
   lastPlayers,
   lastPlayerTargetScores,
@@ -104,7 +104,7 @@ export const GameRouter: FC<GameRouterProps> = ({
           gameId={gameId}
           setGameId={setGameId}
           finishGame={onFinishGame}
-          supabase={supabase}
+          backend={backend}
           user={user}
           breakingPlayerId={breakingPlayerId}
           shotClockSeconds={shotClockSeconds}
@@ -122,7 +122,7 @@ export const GameRouter: FC<GameRouterProps> = ({
       return (
         <GameStatistics
           gameId={gameId}
-          supabase={supabase}
+          backend={backend}
           startNewGame={onStartNewGame}
           viewHistory={onViewHistory}
           user={user}
@@ -131,22 +131,17 @@ export const GameRouter: FC<GameRouterProps> = ({
     case 'history':
       return (
         <GameHistory
-          supabase={supabase}
+          backend={backend}
           startNewGame={onGoToSetup}
           user={user}
           viewTrends={onViewTrends}
         />
       );
     case 'trends':
-      return <TrendsPage supabase={supabase} user={user} onStartNewGame={onGoToSetup} />;
+      return <TrendsPage backend={backend} user={user} onStartNewGame={onGoToSetup} />;
     case 'profile':
       return (
-        <UserProfile
-          supabase={supabase}
-          user={user!}
-          onSignOut={onSignOut}
-          showPageTitle
-        />
+        <UserProfile backend={backend} user={user!} onSignOut={onSignOut} showPageTitle />
       );
     default:
       return <GameSetup startGame={onStartGame} />;

--- a/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
@@ -33,8 +33,8 @@ vi.mock('../../../context/GamePersistContext', async () => {
   };
 });
 
-const supabase = {
-  from: () => ({ upsert: async () => ({ data: null, error: null }) }),
+const backend = {
+  saveGame: vi.fn(async () => undefined),
 } as any;
 
 describe('GameScoring consecutive foul flow', () => {
@@ -94,7 +94,7 @@ describe('GameScoring consecutive foul flow', () => {
         gameId="saved-game-1"
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}

--- a/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.integration.test.tsx
@@ -25,8 +25,8 @@ vi.mock('../../../context/GamePersistContext', async () => {
   };
 });
 
-const supabase = {
-  from: () => ({ upsert: async () => ({ data: null, error: null }) }),
+const backend = {
+  saveGame: vi.fn(async () => undefined),
 } as any;
 
 describe('GameScoring integration', () => {
@@ -43,7 +43,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -72,7 +72,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={1}
         shotClockSeconds={15}
@@ -106,7 +106,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -145,7 +145,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -180,7 +180,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -214,7 +214,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -247,7 +247,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={15}
@@ -277,7 +277,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={null}
@@ -304,7 +304,7 @@ describe('GameScoring integration', () => {
         gameId={null}
         setGameId={() => {}}
         finishGame={() => {}}
-        supabase={supabase}
+        backend={backend}
         user={null}
         breakingPlayerId={0}
         shotClockSeconds={35}

--- a/src/components/GameScoring/index.tsx
+++ b/src/components/GameScoring/index.tsx
@@ -87,7 +87,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
   gameId,
   setGameId,
   finishGame,
-  supabase,
+  backend,
   user,
   breakingPlayerId = 0,
   shotClockSeconds,
@@ -119,46 +119,36 @@ const GameScoring: React.FC<GameScoringProps> = ({
   const [currentBreakingPlayerId, setCurrentBreakingPlayerId] =
     useState<number>(breakingPlayerId);
 
-  // Add effect to detect user login and save game to SupaBase
+  // Add effect to detect user login and save game to cloud backend
   useEffect(() => {
-    // If user just logged in and we have a game in progress, save it to SupaBase
+    // If user just logged in and we have a game in progress, save it to cloud backend
     if (user && gameId) {
-      const saveCurrentGameToSupabase = async () => {
+      const saveCurrentGameToCloud = async () => {
         try {
           const gameState = getGameState();
           if (!gameState) return;
 
-          const now = new Date();
           const payload = {
             id: gameId,
-            date: now.toISOString(),
+            date: new Date().toISOString(),
             players: gameState.players,
             actions: gameState.actions,
             completed: gameState.completed,
             winner_id: gameState.winner_id,
-            owner_id: user.id,
             deleted: false,
           };
 
-          const { error } = await supabase.from('games').upsert(payload);
-
-          if (error) {
-            console.error('Error saving game to Supabase after login:', error);
-            addError(
-              'Could not save your in-progress game to the cloud after login. Your local progress is safe.',
-            );
-          } else {
-            console.log('Successfully saved game to Supabase after login');
-          }
+          await backend.saveGame(payload, user);
+          console.log('Successfully saved game to cloud backend after login');
         } catch (err) {
-          console.error('Error saving game to Supabase after login:', err);
+          console.error('Error saving game to cloud backend after login:', err);
           addError('A network error occurred while saving your game. Please try again.');
         }
       };
 
-      saveCurrentGameToSupabase();
+      saveCurrentGameToCloud();
     }
-  }, [user, gameId, supabase, getGameState]);
+  }, [user, gameId, backend, getGameState, addError]);
 
   // Game state management
   const {
@@ -203,7 +193,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
     ) => {
       try {
         await saveGameToSupabaseHelper({
-          supabase,
+          backend,
           user,
           saveGameState,
           clearGameState,
@@ -225,7 +215,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
           winner_id,
         });
       } catch (_error) {
-        console.error('Failed to persist game to Supabase', _error);
+        console.error('Failed to persist game to cloud backend', _error);
         addError(
           'Failed to save your game. Changes are saved locally and will sync when online.',
         );
@@ -254,7 +244,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
       ) => {
         try {
           await saveGameToSupabaseHelper({
-            supabase,
+            backend,
             user,
             saveGameState,
             clearGameState,
@@ -276,7 +266,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
             winner_id,
           });
         } catch (_error) {
-          console.error('Failed to persist action to Supabase', _error);
+          console.error('Failed to persist action to cloud backend', _error);
           addError(
             'Could not save your recent action to the cloud. It will retry automatically.',
           );
@@ -317,7 +307,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
     ) => {
       try {
         await saveGameToSupabaseHelper({
-          supabase,
+          backend,
           user,
           saveGameState,
           clearGameState,
@@ -335,7 +325,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
           winner_id,
         });
       } catch (_error) {
-        console.error('Failed to persist updated history to Supabase', _error);
+        console.error('Failed to persist updated history to cloud backend', _error);
         addError(
           'Failed to update game history in the cloud. Your local history is intact.',
         );
@@ -491,7 +481,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
       }
 
       void saveGameToSupabaseHelper({
-        supabase,
+        backend,
         user,
         saveGameState,
         clearGameState,

--- a/src/components/GameStatistics.tsx
+++ b/src/components/GameStatistics.tsx
@@ -48,7 +48,7 @@ const deriveHeadline = (game: GameData): { primary: string; secondary?: string }
 
 const GameStatistics: React.FC<GameStatisticsProps> = ({
   gameId,
-  supabase,
+  backend,
   startNewGame,
   viewHistory,
   user,
@@ -93,21 +93,11 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
           console.log('No game found in localStorage, trying Supabase');
         }
 
-        // If no local data, try Supabase
-        const { data, error } = await supabase
-          .from('games')
-          .select('*')
-          .eq('id', gameId)
-          .eq('deleted', false)
-          .single();
+        // If no local data, try cloud backend
+        const data = await backend.getGame(gameId);
 
-        if (error) {
-          console.error('Error fetching from Supabase:', error);
-          throw error;
-        }
-
-        console.log('Fetched game data from Supabase:', data);
-        setGameData(data as unknown as GameData);
+        console.log('Fetched game data from cloud backend:', data);
+        setGameData(data);
       } catch (err) {
         console.error('Error in fetchGameData:', err);
         setError('Failed to load game data');
@@ -117,38 +107,31 @@ const GameStatistics: React.FC<GameStatisticsProps> = ({
     };
 
     fetchGameData();
-  }, [gameId, supabase]);
+  }, [gameId, backend]);
 
-  // Effect to save game to Supabase when user logs in
+  // Effect to save game to cloud backend when user logs in
   useEffect(() => {
     if (user && gameData && !savedToSupabase) {
-      const saveGameToSupabase = async () => {
+      const saveGameToCloud = async () => {
         try {
-          console.log('Saving game to Supabase after login on results screen');
+          console.log('Saving game to cloud backend after login on results screen');
 
-          // Create payload from the gameData
-          const payload = {
+          const payload: GameData = {
             ...gameData,
-            owner_id: user.id,
             deleted: false,
           };
 
-          const { error } = await supabase.from('games').upsert(payload);
-
-          if (error) {
-            console.error('Error saving game to Supabase after login:', error);
-          } else {
-            console.log('Successfully saved game to Supabase after login');
-            setSavedToSupabase(true);
-          }
+          await backend.saveGame(payload, user);
+          console.log('Successfully saved game to cloud backend after login');
+          setSavedToSupabase(true);
         } catch (err) {
-          console.error('Error saving game to Supabase after login:', err);
+          console.error('Error saving game to cloud backend after login:', err);
         }
       };
 
-      saveGameToSupabase();
+      saveGameToCloud();
     }
-  }, [user, gameData, supabase, savedToSupabase]);
+  }, [user, gameData, backend, savedToSupabase]);
 
   const formatGameResultsForEmail = useMemo(() => {
     if (!gameData) return '';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react';
 
-import type { User } from '@supabase/supabase-js';
+import type { AppUser } from '../types/auth';
 
 interface HeaderProps {
-  user: User | null;
+  user: AppUser | null;
   darkMode: boolean;
   isFullScreen: boolean;
   toggleDarkMode: () => void;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,11 +1,11 @@
 import type { FC } from 'react';
 
 import type { GameState } from '../hooks/useGameState';
-import type { User } from '@supabase/supabase-js';
+import type { AppUser } from '../types/auth';
 
 interface NavigationProps {
   gameState: GameState;
-  user: User | null;
+  user: AppUser | null;
   onNavigate: (state: GameState) => void;
 }
 

--- a/src/components/Trends/__tests__/TrendsPage.test.tsx
+++ b/src/components/Trends/__tests__/TrendsPage.test.tsx
@@ -21,10 +21,9 @@ vi.mock('recharts', () => ({
   YAxis: () => null,
 }));
 
-const mockSupabase = {
-  from: vi.fn(),
-  channel: vi.fn(),
-  removeChannel: vi.fn(),
+const mockBackend = {
+  listGames: vi.fn(),
+  deleteGame: vi.fn(),
 } as any;
 
 const mockUser = { id: 'user-1', email: 'test@example.com' } as any;
@@ -65,7 +64,7 @@ const buildGame = (overrides: Partial<GameData> = {}): GameData => ({
 });
 
 const renderPage = () =>
-  render(<TrendsPage supabase={mockSupabase} user={mockUser} onStartNewGame={vi.fn()} />);
+  render(<TrendsPage backend={mockBackend} user={mockUser} onStartNewGame={vi.fn()} />);
 
 describe('TrendsPage', () => {
   beforeEach(() => {

--- a/src/components/Trends/hooks/useTrendsData.ts
+++ b/src/components/Trends/hooks/useTrendsData.ts
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
-
 import { useGameHistory } from '../../GameHistory/hooks/useGameHistory';
 import {
   buildPlayerTrendData,
@@ -12,9 +10,12 @@ import {
   type TrendsSummary,
 } from '../utils/trendsData';
 
+import type { GameBackend } from '../../../backend/types';
+import type { AppUser } from '../../../types/auth';
+
 interface UseTrendsDataParams {
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
 }
 
 interface UseTrendsDataResult {
@@ -30,10 +31,10 @@ interface UseTrendsDataResult {
 }
 
 export const useTrendsData = ({
-  supabase,
+  backend,
   user,
 }: UseTrendsDataParams): UseTrendsDataResult => {
-  const { games, loading, error } = useGameHistory({ supabase, user });
+  const { games, loading, error } = useGameHistory({ backend, user });
 
   const playerOptions = useMemo(() => getTrendsPlayerOptions(games), [games]);
   const [selectedPlayerKey, setSelectedPlayerKey] = useState<string>('');

--- a/src/components/Trends/index.tsx
+++ b/src/components/Trends/index.tsx
@@ -1,7 +1,5 @@
 import { useMemo, useState, type FC } from 'react';
 
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
-
 import { MetricToggle, type MetricDefinition } from './components/MetricToggle';
 import { PlayerSelector } from './components/PlayerSelector';
 import { SummaryCards } from './components/SummaryCards';
@@ -9,6 +7,8 @@ import { TrendChart, type TrendSeries } from './components/TrendChart';
 import { useTrendsData } from './hooks/useTrendsData';
 
 import type { TrendMetric } from './utils/trendsData';
+import type { GameBackend } from '../../backend/types';
+import type { AppUser } from '../../types/auth';
 
 const METRIC_DECIMALS: Record<TrendMetric, number> = {
   bpi: 2,
@@ -25,8 +25,8 @@ const METRIC_UNITS: Record<TrendMetric, string> = {
 };
 
 interface TrendsPageProps {
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
   onStartNewGame: () => void;
 }
 
@@ -40,7 +40,7 @@ const METRIC_DEFINITIONS: MetricDefinition[] = [
 const TRENDS_REQUIRED_GAMES = 3;
 const TRENDS_DELTA_MIN_GAMES = 10;
 
-const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => {
+const TrendsPage: FC<TrendsPageProps> = ({ backend, user, onStartNewGame }) => {
   const {
     loading,
     error,
@@ -51,7 +51,7 @@ const TrendsPage: FC<TrendsPageProps> = ({ supabase, user, onStartNewGame }) => 
     trendPoints,
     summary,
     hasAnyCompletedGames,
-  } = useTrendsData({ supabase, user });
+  } = useTrendsData({ backend, user });
 
   const [visibleMetrics, setVisibleMetrics] = useState<TrendMetric[]>(() =>
     METRIC_DEFINITIONS.map((metric) => metric.key),

--- a/src/components/__tests__/GameHistory.test.tsx
+++ b/src/components/__tests__/GameHistory.test.tsx
@@ -22,14 +22,9 @@ vi.mock('../GameHistory/components/DeleteConfirmationModal', () => ({
   ),
 }));
 
-// Mock Supabase
-const mockSupabase = {
-  from: vi.fn(() => ({
-    select: vi.fn(),
-    insert: vi.fn(),
-    update: vi.fn(),
-    delete: vi.fn(),
-  })),
+const mockBackend = {
+  listGames: vi.fn(),
+  deleteGame: vi.fn(),
 };
 
 const mockUser = { id: 'user-1', email: 'test@example.com' } as any;
@@ -57,11 +52,7 @@ describe('GameHistory Component', () => {
 
   test('renders GameList component by default', () => {
     render(
-      <GameHistory
-        supabase={mockSupabase as any}
-        startNewGame={vi.fn()}
-        user={mockUser}
-      />,
+      <GameHistory backend={mockBackend as any} startNewGame={vi.fn()} user={mockUser} />,
     );
 
     expect(screen.getByTestId('game-list')).toBeInTheDocument();
@@ -69,7 +60,7 @@ describe('GameHistory Component', () => {
 
   test('renders without user (guest mode)', () => {
     render(
-      <GameHistory supabase={mockSupabase as any} startNewGame={vi.fn()} user={null} />,
+      <GameHistory backend={mockBackend as any} startNewGame={vi.fn()} user={null} />,
     );
 
     expect(screen.getByTestId('game-list')).toBeInTheDocument();
@@ -85,11 +76,7 @@ describe('GameHistory Component', () => {
     });
 
     render(
-      <GameHistory
-        supabase={mockSupabase as any}
-        startNewGame={vi.fn()}
-        user={mockUser}
-      />,
+      <GameHistory backend={mockBackend as any} startNewGame={vi.fn()} user={mockUser} />,
     );
 
     // Should render a loading status
@@ -108,11 +95,7 @@ describe('GameHistory Component', () => {
     } as any);
 
     render(
-      <GameHistory
-        supabase={mockSupabase as any}
-        startNewGame={vi.fn()}
-        user={mockUser}
-      />,
+      <GameHistory backend={mockBackend as any} startNewGame={vi.fn()} user={mockUser} />,
     );
 
     // Error banner renders with Start New Game button
@@ -147,11 +130,7 @@ describe('GameHistory Component', () => {
     } as any);
 
     render(
-      <GameHistory
-        supabase={mockSupabase as any}
-        startNewGame={vi.fn()}
-        user={mockUser}
-      />,
+      <GameHistory backend={mockBackend as any} startNewGame={vi.fn()} user={mockUser} />,
     );
 
     expect(screen.getByTestId('game-list')).toBeInTheDocument();

--- a/src/components/__tests__/GameStatistics.test.tsx
+++ b/src/components/__tests__/GameStatistics.test.tsx
@@ -40,19 +40,9 @@ Object.defineProperty(window, 'localStorage', {
   value: localStorageMock,
 });
 
-// Mock Supabase with chainable query builder (including upsert for save on login)
-const mockSupabase = {
-  from: vi.fn(() => {
-    const query: any = {
-      select: vi.fn(() => query),
-      eq: vi.fn(() => query),
-      single: vi.fn(async () => ({ data: null, error: null })),
-      upsert: vi.fn(async () => ({ data: null, error: null })),
-      insert: vi.fn(async () => ({ data: null, error: null })),
-      order: vi.fn(async () => ({ data: [], error: null })),
-    };
-    return query;
-  }),
+const mockBackend = {
+  getGame: vi.fn(async () => null),
+  saveGame: vi.fn(async () => undefined),
 };
 
 const mockGameData: GameData = {
@@ -94,6 +84,8 @@ const mockGameData: GameData = {
 describe('GameStatistics Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockBackend.getGame.mockResolvedValue(null);
+    mockBackend.saveGame.mockResolvedValue(undefined);
     localStorage.clear();
   });
 
@@ -101,7 +93,7 @@ describe('GameStatistics Component', () => {
     render(
       <GameStatistics
         gameId="game-1"
-        supabase={mockSupabase as any}
+        backend={mockBackend as any}
         startNewGame={vi.fn()}
         viewHistory={vi.fn()}
         user={null}
@@ -121,7 +113,7 @@ describe('GameStatistics Component', () => {
     render(
       <GameStatistics
         gameId=""
-        supabase={mockSupabase as any}
+        backend={mockBackend as any}
         startNewGame={vi.fn()}
         viewHistory={vi.fn()}
         user={null}
@@ -139,7 +131,7 @@ describe('GameStatistics Component', () => {
     render(
       <GameStatistics
         gameId="game-1"
-        supabase={mockSupabase as any}
+        backend={mockBackend as any}
         startNewGame={vi.fn()}
         viewHistory={vi.fn()}
         user={null}
@@ -158,7 +150,7 @@ describe('GameStatistics Component', () => {
     render(
       <GameStatistics
         gameId="game-1"
-        supabase={mockSupabase as any}
+        backend={mockBackend as any}
         startNewGame={vi.fn()}
         viewHistory={vi.fn()}
         user={null}
@@ -176,7 +168,7 @@ describe('GameStatistics Component', () => {
     render(
       <GameStatistics
         gameId="game-1"
-        supabase={mockSupabase as any}
+        backend={mockBackend as any}
         startNewGame={vi.fn()}
         viewHistory={vi.fn()}
         user={{ id: 'user-1' } as any}

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
-
 import { formatGameDateTime } from '../../utils/formatGameDate';
 
+import type { GameBackend } from '../../backend/types';
+import type { AppUser } from '../../types/auth';
+
 interface UserProfileProps {
-  supabase: SupabaseClient;
-  user: User;
+  backend: GameBackend;
+  user: AppUser;
   onSignOut: () => Promise<void>;
   /**
    * Render the per-screen kicker + bold title block. Off by default so
@@ -39,8 +40,8 @@ interface ProfileStats {
 }
 
 const useProfileStats = (
-  supabase: SupabaseClient,
-  userId: string | undefined,
+  backend: GameBackend,
+  user: AppUser | undefined,
 ): ProfileStats => {
   const [stats, setStats] = useState<ProfileStats>({
     loading: true,
@@ -49,41 +50,33 @@ const useProfileStats = (
   });
 
   useEffect(() => {
-    if (!userId) {
+    if (!user) {
       setStats({ loading: false, totalGames: 0, lastGameDate: null });
       return;
     }
 
     let cancelled = false;
     (async () => {
-      // One round-trip for both counters: order by date desc, then derive
-      // total = data.length and last = data[0]?.date. Cheap because each
-      // row only carries the date column. Acceptable while game volume per
-      // account stays small.
-      const { data, error } = await supabase
-        .from('games')
-        .select('date')
-        .eq('owner_id', userId)
-        .eq('deleted', false)
-        .order('date', { ascending: false });
+      try {
+        const data = await backend.getProfileStats(user);
 
-      if (cancelled) return;
-      if (error || !data) {
-        setStats({ loading: false, totalGames: 0, lastGameDate: null });
-        return;
+        if (cancelled) return;
+        setStats({
+          loading: false,
+          totalGames: data.totalGames,
+          lastGameDate: data.lastGameDate,
+        });
+      } catch {
+        if (!cancelled) {
+          setStats({ loading: false, totalGames: 0, lastGameDate: null });
+        }
       }
-
-      setStats({
-        loading: false,
-        totalGames: data.length,
-        lastGameDate: data.length > 0 && data[0]?.date ? String(data[0].date) : null,
-      });
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [supabase, userId]);
+  }, [backend, user]);
 
   return stats;
 };
@@ -137,7 +130,7 @@ const SubmitSpinner: React.FC = () => (
 );
 
 const UserProfile: React.FC<UserProfileProps> = ({
-  supabase,
+  backend,
   user,
   onSignOut,
   showPageTitle = false,
@@ -155,7 +148,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
     loading: statsLoading,
     totalGames,
     lastGameDate,
-  } = useProfileStats(supabase, user.id);
+  } = useProfileStats(backend, user);
 
   const handleUpdateEmail = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -165,11 +158,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
       setError(null);
       setMessage(null);
 
-      const { error } = await supabase.auth.updateUser({
-        email: newEmail,
-      });
-
-      if (error) throw error;
+      if (!backend.updateEmail) {
+        throw new Error('Email updates are part of the Phase 2 Cognito signup work.');
+      }
+      await backend.updateEmail(newEmail);
 
       setMessage('Email update initiated. Check your new email for confirmation!');
       setNewEmail('');
@@ -195,11 +187,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
       setError(null);
       setMessage(null);
 
-      const { error } = await supabase.auth.updateUser({
-        password: newPassword,
-      });
-
-      if (error) throw error;
+      if (!backend.updatePassword) {
+        throw new Error('Password updates are part of the Phase 2 Cognito signup work.');
+      }
+      await backend.updatePassword(newPassword);
 
       setMessage('Password updated successfully!');
       setNewPassword('');

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -149,6 +149,8 @@ const UserProfile: React.FC<UserProfileProps> = ({
     totalGames,
     lastGameDate,
   } = useProfileStats(backend, user);
+  const canUpdateEmail = Boolean(backend.updateEmail);
+  const canUpdatePassword = Boolean(backend.updatePassword);
 
   const handleUpdateEmail = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -263,89 +265,91 @@ const UserProfile: React.FC<UserProfileProps> = ({
           </dl>
         </SectionCard>
 
-        {/* Change email */}
-        <SectionCard heading="Change email">
-          <form onSubmit={handleUpdateEmail} className="space-y-3">
-            <div>
-              <label
-                htmlFor="new-email"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                New email
-              </label>
-              <input
-                id="new-email"
-                type="email"
-                value={newEmail}
-                onChange={(e) => setNewEmail(e.target.value)}
-                required
-                disabled={loading}
-                placeholder="you@example.com"
-                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
-              />
-            </div>
-            <div className="flex justify-end">
-              <button
-                type="submit"
-                disabled={loading || !newEmail}
-                className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading && <SubmitSpinner />}
-                {loading ? 'Updating…' : 'Update email'}
-              </button>
-            </div>
-          </form>
-        </SectionCard>
+        {canUpdateEmail && (
+          <SectionCard heading="Change email">
+            <form onSubmit={handleUpdateEmail} className="space-y-3">
+              <div>
+                <label
+                  htmlFor="new-email"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  New email
+                </label>
+                <input
+                  id="new-email"
+                  type="email"
+                  value={newEmail}
+                  onChange={(e) => setNewEmail(e.target.value)}
+                  required
+                  disabled={loading}
+                  placeholder="you@example.com"
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
+                />
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={loading || !newEmail}
+                  className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {loading && <SubmitSpinner />}
+                  {loading ? 'Updating…' : 'Update email'}
+                </button>
+              </div>
+            </form>
+          </SectionCard>
+        )}
 
-        {/* Change password */}
-        <SectionCard heading="Change password">
-          <form onSubmit={handleUpdatePassword} className="space-y-3">
-            <div>
-              <label
-                htmlFor="new-password"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                New password
-              </label>
-              <input
-                id="new-password"
-                type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                required
-                disabled={loading}
-                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="confirm-password"
-                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-              >
-                Confirm new password
-              </label>
-              <input
-                id="confirm-password"
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                disabled={loading}
-                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
-              />
-            </div>
-            <div className="flex justify-end">
-              <button
-                type="submit"
-                disabled={loading || !newPassword || !confirmPassword}
-                className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {loading && <SubmitSpinner />}
-                {loading ? 'Updating…' : 'Update password'}
-              </button>
-            </div>
-          </form>
-        </SectionCard>
+        {canUpdatePassword && (
+          <SectionCard heading="Change password">
+            <form onSubmit={handleUpdatePassword} className="space-y-3">
+              <div>
+                <label
+                  htmlFor="new-password"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  New password
+                </label>
+                <input
+                  id="new-password"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  disabled={loading}
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="confirm-password"
+                  className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                >
+                  Confirm new password
+                </label>
+                <input
+                  id="confirm-password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  disabled={loading}
+                  className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
+                />
+              </div>
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={loading || !newPassword || !confirmPassword}
+                  className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {loading && <SubmitSpinner />}
+                  {loading ? 'Updating…' : 'Update password'}
+                </button>
+              </div>
+            </form>
+          </SectionCard>
+        )}
       </div>
 
       {/* Sign out — demoted to a quiet outline pill in the page footer.

--- a/src/components/modals/ProfileModal.tsx
+++ b/src/components/modals/ProfileModal.tsx
@@ -2,13 +2,13 @@ import type { FC } from 'react';
 
 import UserProfile from '../auth/UserProfile';
 
-import type { User } from '@supabase/supabase-js';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import type { GameBackend } from '../../backend/types';
+import type { AppUser } from '../../types/auth';
 
 interface ProfileModalProps {
   isOpen: boolean;
-  user: User | null;
-  supabase: SupabaseClient;
+  user: AppUser | null;
+  backend: GameBackend;
   onClose: () => void;
   onSignOut: () => Promise<void>;
 }
@@ -16,7 +16,7 @@ interface ProfileModalProps {
 export const ProfileModal: FC<ProfileModalProps> = ({
   isOpen,
   user,
-  supabase,
+  backend,
   onClose,
   onSignOut,
 }) => {
@@ -35,7 +35,7 @@ export const ProfileModal: FC<ProfileModalProps> = ({
           </button>
         </div>
         <div className="p-4">
-          <UserProfile supabase={supabase} user={user} onSignOut={onSignOut} />
+          <UserProfile backend={backend} user={user} onSignOut={onSignOut} />
         </div>
       </div>
     </div>

--- a/src/hooks/useGameSave.test.ts
+++ b/src/hooks/useGameSave.test.ts
@@ -9,20 +9,15 @@ describe('saveGameToSupabaseHelper', () => {
 
   let saveGameState: any;
   let clearGameState: any;
-  let supabase: any;
-  let upsertSpy: any;
-  let tableName: string | null;
+  let backend: any;
+  let saveGameSpy: any;
 
   beforeEach(() => {
     saveGameState = vi.fn();
     clearGameState = vi.fn();
-    upsertSpy = vi.fn(async () => ({ error: null }));
-    tableName = null;
-    supabase = {
-      from: (t: string) => {
-        tableName = t;
-        return { upsert: upsertSpy };
-      },
+    saveGameSpy = vi.fn(async () => undefined);
+    backend = {
+      saveGame: saveGameSpy,
     };
     vi.spyOn(window.localStorage.__proto__, 'setItem');
     (window.localStorage.setItem as any).mockClear();
@@ -30,7 +25,7 @@ describe('saveGameToSupabaseHelper', () => {
 
   it('saves to localStorage and context but not Supabase when user is null', async () => {
     await saveGameToSupabaseHelper({
-      supabase,
+      backend,
       user: null,
       saveGameState,
       clearGameState,
@@ -49,15 +44,14 @@ describe('saveGameToSupabaseHelper', () => {
       `runcount_game_${gameId}`,
       expect.stringContaining('"id":"game-123"'),
     );
-    expect(tableName).toBe(null);
-    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(saveGameSpy).not.toHaveBeenCalled();
   });
 
-  it('saves to Supabase when user is present', async () => {
+  it('saves to cloud backend when user is present', async () => {
     const user = { id: 'user-42' };
 
     await saveGameToSupabaseHelper({
-      supabase,
+      backend,
       user,
       saveGameState,
       clearGameState,
@@ -71,20 +65,19 @@ describe('saveGameToSupabaseHelper', () => {
     });
 
     expect(saveGameState).toHaveBeenCalledTimes(1);
-    expect(tableName).toBe('games');
-    expect(upsertSpy).toHaveBeenCalledTimes(1);
-    const payload = upsertSpy.mock.calls[0][0];
+    expect(saveGameSpy).toHaveBeenCalledTimes(1);
+    const payload = saveGameSpy.mock.calls[0][0];
     expect(payload).toMatchObject({
       id: gameId,
       players,
       actions,
       completed: false,
       winner_id: 0,
-      owner_id: user.id,
       deleted: false,
       startTime: '2025-08-17T00:00:00.000Z',
       endTime: '2025-08-17T01:00:00.000Z',
     });
+    expect(saveGameSpy.mock.calls[0][1]).toBe(user);
     expect(typeof payload.date).toBe('string');
   });
 
@@ -92,7 +85,7 @@ describe('saveGameToSupabaseHelper', () => {
     const user = { id: 'user-42' };
 
     await saveGameToSupabaseHelper({
-      supabase,
+      backend,
       user,
       saveGameState,
       clearGameState,
@@ -108,6 +101,6 @@ describe('saveGameToSupabaseHelper', () => {
     expect(clearGameState).toHaveBeenCalledTimes(1);
     expect(saveGameState).not.toHaveBeenCalled();
     expect(window.localStorage.setItem).toHaveBeenCalled();
-    expect(upsertSpy).toHaveBeenCalled();
+    expect(saveGameSpy).toHaveBeenCalled();
   });
 });

--- a/src/hooks/useGameSave.ts
+++ b/src/hooks/useGameSave.ts
@@ -1,10 +1,10 @@
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
-
+import type { GameBackend } from '../backend/types';
+import type { AppUser } from '../types/auth';
 import type { GameAction, GameData, Player } from '../types/game';
 
 type UseGameSaveArgs = {
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
   saveGameState: (state: GameData) => void;
   clearGameState: () => void;
   matchStartTime?: string;
@@ -14,14 +14,9 @@ type UseGameSaveArgs = {
 
 type WinnerId = number | string | null;
 
-type SupabaseGamePayload = GameData & {
-  owner_id: string;
-  deleted: boolean;
-};
-
 export const saveGameToSupabaseHelper = async (options: {
-  supabase: SupabaseClient;
-  user: User | null;
+  backend: GameBackend;
+  user: AppUser | null;
   saveGameState: (state: GameData) => void;
   clearGameState: () => void;
   matchStartTime?: string;
@@ -34,7 +29,7 @@ export const saveGameToSupabaseHelper = async (options: {
   winner_id: WinnerId;
 }) => {
   const {
-    supabase,
+    backend,
     user,
     saveGameState,
     clearGameState,
@@ -96,14 +91,13 @@ export const saveGameToSupabaseHelper = async (options: {
 
   try {
     const now = new Date();
-    const payload: SupabaseGamePayload = {
+    const payload: GameData = {
       id: gameId,
       date: now.toISOString(),
       players,
       actions,
       completed,
       winner_id: winnerId,
-      owner_id: user.id,
       deleted: false,
     };
 
@@ -117,34 +111,22 @@ export const saveGameToSupabaseHelper = async (options: {
       payload.turnStartTime = turnStartTime;
     }
 
-    const { error } = await supabase.from('games').upsert(payload);
-
-    if (error) {
-      console.error('Error saving game to Supabase:', error);
-      try {
-        const evt = new CustomEvent('appError', {
-          detail: "Cloud save failed. We'll keep trying in the background.",
-        });
-        window.dispatchEvent(evt);
-      } catch (dispatchError) {
-        console.warn('Unable to dispatch Supabase save warning', dispatchError);
-      }
-    }
+    await backend.saveGame(payload, user);
   } catch (err) {
-    console.error('Error saving game to Supabase:', err);
+    console.error('Error saving game to cloud backend:', err);
     try {
       const evt = new CustomEvent('appError', {
         detail: 'Network error during cloud save.',
       });
       window.dispatchEvent(evt);
     } catch (dispatchError) {
-      console.warn('Unable to dispatch Supabase network warning', dispatchError);
+      console.warn('Unable to dispatch cloud save warning', dispatchError);
     }
   }
 };
 
 export const useGameSave = ({
-  supabase,
+  backend,
   user,
   saveGameState,
   clearGameState,
@@ -161,7 +143,7 @@ export const useGameSave = ({
     endTime?: string,
   ) => {
     await saveGameToSupabaseHelper({
-      supabase,
+      backend,
       user,
       saveGameState,
       clearGameState,

--- a/src/lib/awsApiClient.ts
+++ b/src/lib/awsApiClient.ts
@@ -1,0 +1,98 @@
+import type { GameData } from '../types/game';
+
+export interface CurrentUserResponse {
+  user: {
+    userId: string;
+    email: string | null;
+    givenName: string | null;
+    familyName: string | null;
+    displayName: string | null;
+  };
+  stats: {
+    totalGames: number;
+    lastGameDate: string | null;
+  };
+}
+
+const rawApiUrl = import.meta.env.VITE_API_URL as string | undefined;
+export const apiUrl = rawApiUrl?.replace(/\/$/, '') ?? '';
+export const isApiConfigured = apiUrl.length > 0;
+
+interface RequestOptions {
+  method?: string;
+  body?: unknown;
+}
+
+async function apiRequest<T>(
+  path: string,
+  token: string,
+  opts: RequestOptions = {},
+): Promise<T> {
+  if (!apiUrl) throw new Error('VITE_API_URL is not configured.');
+
+  const init: RequestInit = {
+    method: opts.method ?? 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+
+  const res = await fetch(`${apiUrl}${path}`, init);
+  const text = await res.text();
+  let data: unknown = null;
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = null;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      data && typeof data === 'object' && data !== null && 'error' in data
+        ? String((data as { error: unknown }).error)
+        : `${res.status} ${res.statusText}`;
+    throw new Error(`API request failed: ${message}`);
+  }
+
+  return data as T;
+}
+
+export async function listGames(token: string): Promise<GameData[]> {
+  const data = await apiRequest<{ games: GameData[] }>('/games', token);
+  return data.games;
+}
+
+export async function getGame(gameId: string, token: string): Promise<GameData> {
+  const data = await apiRequest<{ game: GameData }>(
+    `/games/${encodeURIComponent(gameId)}`,
+    token,
+  );
+  return data.game;
+}
+
+export async function saveGame(game: GameData, token: string): Promise<GameData> {
+  const data = await apiRequest<{ game: GameData }>(
+    `/games/${encodeURIComponent(game.id)}`,
+    token,
+    {
+      method: 'PUT',
+      body: game,
+    },
+  );
+  return data.game;
+}
+
+export async function deleteGame(gameId: string, token: string): Promise<void> {
+  await apiRequest<void>(`/games/${encodeURIComponent(gameId)}`, token, {
+    method: 'DELETE',
+  });
+}
+
+export async function getCurrentUser(token: string): Promise<CurrentUserResponse> {
+  return apiRequest<CurrentUserResponse>('/users/me', token);
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,9 +1,21 @@
 /// <reference types="vite/client" />
 
-// Optional: augment env types if you want stricter typing for your VITE_ vars
-// interface ImportMetaEnv {
-//   readonly VITE_SUPABASE_KEY: string
-// }
-// interface ImportMeta {
-//   readonly env: ImportMetaEnv
-// }
+interface ImportMetaEnv {
+  readonly VITE_BACKEND?: 'supabase' | 'aws';
+  readonly VITE_SUPABASE_KEY?: string;
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_API_URL?: string;
+  readonly VITE_AUTH_MOCK?: string;
+  readonly VITE_AUTH_MOCK_SUB?: string;
+  readonly VITE_AUTH_MOCK_EMAIL?: string;
+  readonly VITE_AUTH_MOCK_GIVEN_NAME?: string;
+  readonly VITE_AUTH_MOCK_FAMILY_NAME?: string;
+  readonly VITE_COGNITO_REGION?: string;
+  readonly VITE_COGNITO_USER_POOL_ID?: string;
+  readonly VITE_COGNITO_CLIENT_ID?: string;
+  readonly VITE_COGNITO_DOMAIN?: string;
+  readonly VITE_COGNITO_REDIRECT_URI?: string;
+  readonly VITE_COGNITO_LOGOUT_URI?: string;
+  readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_DISABLE_SUPABASE_REALTIME?: string;
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,18 @@
+export interface AppUser {
+  id: string;
+  email?: string;
+  created_at?: string;
+  user_metadata?: {
+    given_name?: string;
+    family_name?: string;
+    name?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface AppSession {
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,4 +1,5 @@
-import { type SupabaseClient, type User } from '@supabase/supabase-js';
+import type { AppUser } from './auth';
+import type { GameBackend } from '../backend/types';
 
 export interface Player {
   id: number;
@@ -63,8 +64,8 @@ export interface GameScoringProps {
   gameId: string | null;
   setGameId: (id: string) => void;
   finishGame: () => void;
-  supabase: SupabaseClient;
-  user?: User | null;
+  backend: GameBackend;
+  user?: AppUser | null;
   breakingPlayerId?: number;
   shotClockSeconds: number | null;
   matchStartTime: Date | null;
@@ -79,16 +80,16 @@ export interface GameScoringProps {
 
 export interface GameStatisticsProps {
   gameId: string | null;
-  supabase: SupabaseClient;
+  backend: GameBackend;
   startNewGame: () => void;
   viewHistory: () => void;
-  user?: User | null;
+  user?: AppUser | null;
 }
 
 export interface GameHistoryProps {
-  supabase: SupabaseClient;
+  backend: GameBackend;
   startNewGame: () => void;
-  user?: User | null;
+  user?: AppUser | null;
   viewTrends?: () => void;
 }
 


### PR DESCRIPTION
## Purpose

Starts #123 by adding an AWS backend foundation alongside the existing Supabase runtime. This is intentionally Phase 1 scope: Cognito/API/DynamoDB scaffolding plus frontend adapter wiring. Signup/account recovery remains #124, and realtime sync remains #125.

## What changed

- Added a CDK infra package under `infra/` for Cognito, API Gateway/Lambda, DynamoDB games storage, and S3/CloudFront hosting.
- Added a Lambda API handler for authenticated game CRUD and `/users/me` profile stats.
- Added Cognito Hosted UI + PKCE auth scaffolding under `src/aws-auth`.
- Added an AWS API client and `GameBackend` adapter interface.
- Refactored game save/history/stat/profile/trends paths to consume `GameBackend` instead of direct Supabase data calls.
- Kept Supabase as the default runtime; `VITE_BACKEND=aws` selects the new AWS auth/backend path.
- Added env docs and ignores for generated infra output.

## Review focus

- Backend ownership enforcement: Lambda must only operate on games keyed by Cognito `sub`.
- Adapter boundary: app components should not leak Supabase assumptions into AWS-mode paths.
- CDK resource choices: table keys/indexes, Cognito config, CORS, frontend bucket/distribution setup.
- Phase boundaries: no accidental signup/account recovery or realtime scope in this PR.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test` — 45 files / 236 tests
- `cd infra && npm run build`
- `cd infra && npx cdk synth -c account=123456789012 -c region=us-east-1 -c googleClientId=dummy.apps.googleusercontent.com`

## Notes

CDK synth emits the current CDK cross-stack-reference advisory warning for `RunCount-dev-Api`; synthesis succeeds.
