### PR TITLE
✨ Add Cognito signup and recovery flows

### DIFF
--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -38,7 +38,7 @@ export class AuthStack extends Stack {
 
     this.userPool = new UserPool(this, 'UserPool', {
       userPoolName: `runcount-${props.envName}`,
-      selfSignUpEnabled: false,
+      selfSignUpEnabled: true,
       signInAliases: { email: true },
       autoVerify: { email: true },
       standardAttributes: {
@@ -75,7 +75,14 @@ export class AuthStack extends Stack {
       userPool: this.userPool,
       userPoolClientName: `runcount-${props.envName}-web`,
       generateSecret: false,
-      supportedIdentityProviders: [UserPoolClientIdentityProvider.GOOGLE],
+      supportedIdentityProviders: [
+        UserPoolClientIdentityProvider.COGNITO,
+        UserPoolClientIdentityProvider.GOOGLE,
+      ],
+      authFlows: {
+        userPassword: true,
+      },
+      preventUserExistenceErrors: true,
       oAuth: {
         flows: { authorizationCodeGrant: true },
         scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],

--- a/infra/lib/auth-stack.ts
+++ b/infra/lib/auth-stack.ts
@@ -41,6 +41,13 @@ export class AuthStack extends Stack {
       selfSignUpEnabled: true,
       signInAliases: { email: true },
       autoVerify: { email: true },
+      passwordPolicy: {
+        minLength: 8,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true,
+      },
       standardAttributes: {
         email: { required: true, mutable: true },
         givenName: { required: false, mutable: true },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,14 +116,21 @@ const AwsAppContent: FC = () => {
     verifyEmailUpdate,
     updatePassword,
   } = useAwsAuth();
+  const isFederatedAwsUser =
+    Boolean(user?.auth_provider) && user?.auth_provider !== 'password';
   const backend = useMemo(
     () =>
-      createAwsBackend(getIdToken, {
-        updateEmail,
-        verifyEmailUpdate,
-        updatePassword,
-      }),
-    [getIdToken, updateEmail, verifyEmailUpdate, updatePassword],
+      createAwsBackend(
+        getIdToken,
+        isFederatedAwsUser
+          ? undefined
+          : {
+              updateEmail,
+              verifyEmailUpdate,
+              updatePassword,
+            },
+      ),
+    [getIdToken, isFederatedAwsUser, updateEmail, verifyEmailUpdate, updatePassword],
   );
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { AwsAuthProvider, useAwsAuth } from './aws-auth/AwsAuthContext';
 import { isAwsBackend } from './aws-auth/config';
 import { createAwsBackend } from './backend/awsBackend';
 import { createSupabaseBackend } from './backend/supabaseBackend';
+import Auth, { type AuthTab, type AwsAuthOperations } from './components/auth/Auth';
 import { GameRouter } from './components/GameRouter';
 import { Header } from './components/Header';
 import { AuthModal } from './components/modals/AuthModal';
@@ -100,8 +101,30 @@ const SupabaseAppContent: FC<SupabaseAppContentProps> = ({ supabase }) => {
 };
 
 const AwsAppContent: FC = () => {
-  const { user, loading, signOut, getIdToken, signIn } = useAwsAuth();
-  const backend = useMemo(() => createAwsBackend(getIdToken), [getIdToken]);
+  const {
+    user,
+    loading,
+    signOut,
+    getIdToken,
+    signIn,
+    signInWithPassword,
+    signUp,
+    confirmSignUp,
+    forgotPassword,
+    confirmForgotPassword,
+    updateEmail,
+    verifyEmailUpdate,
+    updatePassword,
+  } = useAwsAuth();
+  const backend = useMemo(
+    () =>
+      createAwsBackend(getIdToken, {
+        updateEmail,
+        verifyEmailUpdate,
+        updatePassword,
+      }),
+    [getIdToken, updateEmail, verifyEmailUpdate, updatePassword],
+  );
 
   return (
     <AppContent
@@ -114,7 +137,14 @@ const AwsAppContent: FC = () => {
           isOpen={isOpen}
           gameState={gameState}
           onClose={onClose}
-          onSignIn={signIn}
+          awsAuth={{
+            signInWithPassword,
+            signInWithGoogle: signIn,
+            signUp,
+            confirmSignUp,
+            forgotPassword,
+            confirmForgotPassword,
+          }}
         />
       )}
     />
@@ -331,21 +361,30 @@ interface AwsAuthModalProps {
   isOpen: boolean;
   gameState: ReturnType<typeof useGameState>['gameState'];
   onClose: () => void;
-  onSignIn: () => Promise<void>;
+  awsAuth: AwsAuthOperations;
 }
 
-const AwsAuthModal: FC<AwsAuthModalProps> = ({
-  isOpen,
-  gameState,
-  onClose,
-  onSignIn,
-}) => {
+const AwsAuthModal: FC<AwsAuthModalProps> = ({ isOpen, gameState, onClose, awsAuth }) => {
+  const [activeTab, setActiveTab] = useState<AuthTab>('login');
+
   if (!isOpen) return null;
+
+  const tabTitles: Record<AuthTab, string> = {
+    login: 'Welcome back',
+    signup: 'Create your account',
+    'reset-password': 'Reset your password',
+  };
+  const tabSubtitles: Record<AuthTab, string> = {
+    login: 'Sign in with email or Google to save games to AWS.',
+    signup: 'Create a Cognito account for cloud game history.',
+    'reset-password': "We'll email a verification code to reset your password.",
+  };
+  const showBenefitsPanel = activeTab !== 'reset-password';
 
   return (
     <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-2 sm:p-4">
       <div
-        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm sm:max-w-lg w-full relative"
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm sm:max-w-lg w-full relative max-h-[90vh] overflow-y-auto"
         role="dialog"
         aria-modal="true"
         aria-labelledby="aws-auth-modal-title"
@@ -357,30 +396,42 @@ const AwsAuthModal: FC<AwsAuthModalProps> = ({
         >
           ✕
         </button>
-        <div className="p-5 text-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-700/60 dark:to-gray-700/30 rounded-t-2xl border-b border-gray-200 dark:border-gray-700">
-          <h2 id="aws-auth-modal-title" className="text-xl font-bold dark:text-white">
-            Sign in to RunCount
+        <div className="p-4 sm:p-5 text-center bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-700/60 dark:to-gray-700/30 rounded-t-2xl border-b border-gray-200 dark:border-gray-700">
+          <h2
+            id="aws-auth-modal-title"
+            className="text-lg sm:text-xl font-bold dark:text-white"
+          >
+            {tabTitles[activeTab]}
           </h2>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Use your Google account to save games to AWS.
+          <p className="mt-1 text-xs sm:text-sm text-gray-500 dark:text-gray-400">
+            {tabSubtitles[activeTab]}
           </p>
         </div>
-        <div className="p-4 space-y-4">
+        <div className="p-3 sm:p-4">
           {gameState === 'scoring' || gameState === 'statistics' ? (
-            <div className="p-3 bg-blue-50 dark:bg-blue-900 text-blue-800 dark:text-blue-100 rounded-lg text-sm">
+            <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900 text-blue-800 dark:text-blue-100 rounded-lg text-sm">
               Logging in will save your current game to your account.
             </div>
-          ) : null}
-          <button
-            type="button"
-            onClick={() => void onSignIn()}
-            className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-          >
-            Continue with Google
-          </button>
-          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
-            Signup, password recovery, and account updates are tracked for Phase 2.
-          </p>
+          ) : (
+            showBenefitsPanel && (
+              <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-800 dark:text-green-100 rounded-lg text-sm">
+                <p className="font-semibold mb-2">Benefits of logging in:</p>
+                <ul className="list-disc list-inside space-y-1">
+                  <li>Save your game history across devices</li>
+                  <li>Track your statistics and progress</li>
+                  <li>Never lose your game data</li>
+                  <li>Access your games from anywhere</li>
+                </ul>
+              </div>
+            )
+          )}
+
+          <Auth
+            awsAuth={awsAuth}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            onAuthSuccess={onClose}
+          />
         </div>
       </div>
     </div>

--- a/src/__tests__/app.end-game.integration.test.tsx
+++ b/src/__tests__/app.end-game.integration.test.tsx
@@ -110,7 +110,7 @@ describe('App end-game flow', () => {
       expect(screen.getByText('Completed')).toBeInTheDocument();
       expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument();
     });
-  });
+  }, 15000);
 
   test('ends a game manually without hitting the error boundary', async () => {
     await startGame();

--- a/src/aws-auth/AwsAuthContext.test.tsx
+++ b/src/aws-auth/AwsAuthContext.test.tsx
@@ -31,6 +31,7 @@ describe('AwsAuthProvider mock-mode password sign-in', () => {
       await result.current.signInWithPassword('player@example.com', 'whatever-password');
     });
 
-    expect(result.current.user?.email).toBe('mock@example.com');
+    expect(result.current.user?.email).toBe('player@example.com');
+    expect(result.current.user?.auth_provider).toBe('password');
   });
 });

--- a/src/aws-auth/AwsAuthContext.test.tsx
+++ b/src/aws-auth/AwsAuthContext.test.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react';
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+// Regression test for mock-mode email/password sign-in. Before the fix,
+// applySession decoded the synthetic 'mock-id-token' (from VITE_AUTH_MOCK)
+// as a real JWT and threw, so the live sign-in click surfaced an error
+// instead of logging the mock user in.
+describe('AwsAuthProvider mock-mode password sign-in', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('VITE_BACKEND', 'aws');
+    vi.stubEnv('VITE_AUTH_MOCK', '1');
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('signs in the mock user without throwing', async () => {
+    const { AwsAuthProvider, useAwsAuth } = await import('./AwsAuthContext');
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <AwsAuthProvider>{children}</AwsAuthProvider>
+    );
+
+    const { result } = renderHook(() => useAwsAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.signInWithPassword('player@example.com', 'whatever-password');
+    });
+
+    expect(result.current.user?.email).toBe('mock@example.com');
+  });
+});

--- a/src/aws-auth/AwsAuthContext.tsx
+++ b/src/aws-auth/AwsAuthContext.tsx
@@ -9,6 +9,17 @@ import React, {
 } from 'react';
 
 import {
+  changePassword,
+  confirmForgotPassword,
+  confirmSignUp,
+  forgotPassword,
+  getUserFromPasswordSession,
+  signInWithPassword,
+  signUpWithPassword,
+  updateEmail,
+  verifyEmailUpdate,
+} from './cognitoClient';
+import {
   completeAwsCallback,
   getFreshIdToken,
   getStoredAwsSession,
@@ -26,6 +37,14 @@ interface AwsAuthContextValue {
   session: AppSession | null;
   loading: boolean;
   signIn: () => Promise<void>;
+  signInWithPassword: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<{ userConfirmed: boolean }>;
+  confirmSignUp: (email: string, code: string) => Promise<void>;
+  forgotPassword: (email: string) => Promise<void>;
+  confirmForgotPassword: (email: string, code: string, password: string) => Promise<void>;
+  updateEmail: (email: string) => Promise<void>;
+  verifyEmailUpdate: (code: string) => Promise<void>;
+  updatePassword: (previousPassword: string, password: string) => Promise<void>;
   signOut: () => Promise<void>;
   getIdToken: () => Promise<string | null>;
   refreshSession: () => Promise<void>;
@@ -96,6 +115,70 @@ export const AwsAuthProvider: React.FC<{ children: React.ReactNode }> = ({
     await startAwsSignIn();
   }, []);
 
+  const handlePasswordSignIn = useCallback(
+    async (email: string, password: string) => {
+      const nextSession = await signInWithPassword(email, password);
+      applySession(nextSession);
+      setUser(getUserFromPasswordSession(nextSession));
+    },
+    [applySession],
+  );
+
+  const handleSignUp = useCallback(async (email: string, password: string) => {
+    return signUpWithPassword(email, password);
+  }, []);
+
+  const handleConfirmSignUp = useCallback(async (email: string, code: string) => {
+    await confirmSignUp(email, code);
+  }, []);
+
+  const handleForgotPassword = useCallback(async (email: string) => {
+    await forgotPassword(email);
+  }, []);
+
+  const handleConfirmForgotPassword = useCallback(
+    async (email: string, code: string, password: string) => {
+      await confirmForgotPassword(email, code, password);
+    },
+    [],
+  );
+
+  const handleUpdateEmail = useCallback(
+    async (email: string) => {
+      const token = await getFreshIdToken(sessionRef.current, applySession);
+      if (!token) throw new Error('You must be signed in to update your email.');
+      const accessToken = sessionRef.current?.accessToken;
+      if (!accessToken) throw new Error('You must be signed in to update your email.');
+      await updateEmail(accessToken, email);
+    },
+    [applySession],
+  );
+
+  const handleUpdatePassword = useCallback(
+    async (previousPassword: string, password: string) => {
+      const token = await getFreshIdToken(sessionRef.current, applySession);
+      if (!token) throw new Error('You must be signed in to update your password.');
+      const accessToken = sessionRef.current?.accessToken;
+      if (!accessToken) {
+        throw new Error('You must be signed in to update your password.');
+      }
+      await changePassword(accessToken, previousPassword, password);
+    },
+    [applySession],
+  );
+
+  const handleVerifyEmailUpdate = useCallback(
+    async (code: string) => {
+      const token = await getFreshIdToken(sessionRef.current, applySession);
+      if (!token) throw new Error('You must be signed in to verify your email.');
+      const accessToken = sessionRef.current?.accessToken;
+      if (!accessToken) throw new Error('You must be signed in to verify your email.');
+      await verifyEmailUpdate(accessToken, code);
+      await getFreshIdToken(sessionRef.current, applySession);
+    },
+    [applySession],
+  );
+
   const signOut = useCallback(async () => {
     signOutAws();
     applySession(null);
@@ -115,11 +198,35 @@ export const AwsAuthProvider: React.FC<{ children: React.ReactNode }> = ({
       session,
       loading,
       signIn,
+      signInWithPassword: handlePasswordSignIn,
+      signUp: handleSignUp,
+      confirmSignUp: handleConfirmSignUp,
+      forgotPassword: handleForgotPassword,
+      confirmForgotPassword: handleConfirmForgotPassword,
+      updateEmail: handleUpdateEmail,
+      verifyEmailUpdate: handleVerifyEmailUpdate,
+      updatePassword: handleUpdatePassword,
       signOut,
       getIdToken,
       refreshSession,
     }),
-    [user, session, loading, signIn, signOut, getIdToken, refreshSession],
+    [
+      user,
+      session,
+      loading,
+      signIn,
+      handlePasswordSignIn,
+      handleSignUp,
+      handleConfirmSignUp,
+      handleForgotPassword,
+      handleConfirmForgotPassword,
+      handleUpdateEmail,
+      handleVerifyEmailUpdate,
+      handleUpdatePassword,
+      signOut,
+      getIdToken,
+      refreshSession,
+    ],
   );
 
   return <AwsAuthContext.Provider value={value}>{children}</AwsAuthContext.Provider>;

--- a/src/aws-auth/AwsAuthContext.tsx
+++ b/src/aws-auth/AwsAuthContext.tsx
@@ -24,7 +24,6 @@ import {
   getFreshIdToken,
   getStoredAwsSession,
   getStoredMockUser,
-  getUserFromSession,
   signOutAws,
   startAwsSignIn,
 } from './session';
@@ -74,7 +73,9 @@ export const AwsAuthProvider: React.FC<{ children: React.ReactNode }> = ({
       return;
     }
     saveTokens(nextSession);
-    setUser(getUserFromSession(nextSession));
+    // Use the mock-aware resolver: the synthetic 'mock-id-token' from
+    // VITE_AUTH_MOCK is not a real JWT, so decoding it directly throws.
+    setUser(getUserFromPasswordSession(nextSession));
   }, []);
 
   useEffect(() => {
@@ -119,7 +120,6 @@ export const AwsAuthProvider: React.FC<{ children: React.ReactNode }> = ({
     async (email: string, password: string) => {
       const nextSession = await signInWithPassword(email, password);
       applySession(nextSession);
-      setUser(getUserFromPasswordSession(nextSession));
     },
     [applySession],
   );

--- a/src/aws-auth/cognitoClient.ts
+++ b/src/aws-auth/cognitoClient.ts
@@ -1,0 +1,193 @@
+import { cognitoConfig, isAwsAuthMock, mockUser } from './config';
+import { saveTokens, userFromIdToken } from './tokens';
+
+import type { AppSession, AppUser } from '../types/auth';
+
+interface CognitoError {
+  __type?: string;
+  message?: string;
+}
+
+interface CognitoAuthResult {
+  AccessToken: string;
+  ExpiresIn: number;
+  IdToken: string;
+  RefreshToken?: string;
+}
+
+interface CognitoInitiateAuthResponse {
+  AuthenticationResult?: CognitoAuthResult;
+}
+
+export interface AwsSignUpResult {
+  userConfirmed: boolean;
+}
+
+const COGNITO_TARGET_PREFIX = 'AWSCognitoIdentityProviderService';
+
+function getCognitoEndpoint(): string {
+  return `https://cognito-idp.${cognitoConfig.region}.amazonaws.com/`;
+}
+
+function getErrorMessage(error: CognitoError): string {
+  const type = error.__type?.split('#').pop();
+  return error.message ?? type ?? 'Cognito request failed';
+}
+
+async function requestCognito<T>(
+  target: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(getCognitoEndpoint(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-amz-json-1.1',
+      'X-Amz-Target': `${COGNITO_TARGET_PREFIX}.${target}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  const data = text ? (JSON.parse(text) as T & CognitoError) : ({} as T & CognitoError);
+
+  if (!res.ok) {
+    throw new Error(getErrorMessage(data));
+  }
+
+  return data;
+}
+
+function toSession(result: CognitoAuthResult): AppSession {
+  return {
+    accessToken: result.AccessToken,
+    idToken: result.IdToken,
+    refreshToken: result.RefreshToken ?? '',
+    expiresAt: Date.now() + (result.ExpiresIn - 30) * 1000,
+  };
+}
+
+export async function signInWithPassword(
+  email: string,
+  password: string,
+): Promise<AppSession> {
+  if (isAwsAuthMock) {
+    const session: AppSession = {
+      accessToken: 'mock-access-token',
+      idToken: 'mock-id-token',
+      refreshToken: 'mock-refresh-token',
+      expiresAt: Date.now() + 60 * 60 * 1000,
+    };
+    localStorage.setItem('runcount.auth.mock-user', JSON.stringify(mockUser));
+    return session;
+  }
+
+  const response = await requestCognito<CognitoInitiateAuthResponse>('InitiateAuth', {
+    AuthFlow: 'USER_PASSWORD_AUTH',
+    ClientId: cognitoConfig.clientId,
+    AuthParameters: {
+      USERNAME: email,
+      PASSWORD: password,
+    },
+  });
+
+  if (!response.AuthenticationResult) {
+    throw new Error('Sign in requires an unsupported challenge.');
+  }
+
+  const session = toSession(response.AuthenticationResult);
+  saveTokens(session);
+  return session;
+}
+
+export async function signUpWithPassword(
+  email: string,
+  password: string,
+): Promise<AwsSignUpResult> {
+  if (isAwsAuthMock) {
+    return { userConfirmed: false };
+  }
+
+  const response = await requestCognito<{ UserConfirmed: boolean }>('SignUp', {
+    ClientId: cognitoConfig.clientId,
+    Username: email,
+    Password: password,
+    UserAttributes: [{ Name: 'email', Value: email }],
+  });
+
+  return { userConfirmed: response.UserConfirmed };
+}
+
+export async function confirmSignUp(email: string, code: string): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('ConfirmSignUp', {
+    ClientId: cognitoConfig.clientId,
+    Username: email,
+    ConfirmationCode: code,
+  });
+}
+
+export async function forgotPassword(email: string): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('ForgotPassword', {
+    ClientId: cognitoConfig.clientId,
+    Username: email,
+  });
+}
+
+export async function confirmForgotPassword(
+  email: string,
+  code: string,
+  password: string,
+): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('ConfirmForgotPassword', {
+    ClientId: cognitoConfig.clientId,
+    Username: email,
+    ConfirmationCode: code,
+    Password: password,
+  });
+}
+
+export async function changePassword(
+  accessToken: string,
+  previousPassword: string,
+  proposedPassword: string,
+): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('ChangePassword', {
+    AccessToken: accessToken,
+    PreviousPassword: previousPassword,
+    ProposedPassword: proposedPassword,
+  });
+}
+
+export async function updateEmail(accessToken: string, email: string): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('UpdateUserAttributes', {
+    AccessToken: accessToken,
+    UserAttributes: [{ Name: 'email', Value: email }],
+  });
+}
+
+export async function verifyEmailUpdate(
+  accessToken: string,
+  code: string,
+): Promise<void> {
+  if (isAwsAuthMock) return;
+
+  await requestCognito('VerifyUserAttribute', {
+    AccessToken: accessToken,
+    AttributeName: 'email',
+    Code: code,
+  });
+}
+
+export function getUserFromPasswordSession(session: AppSession): AppUser {
+  if (session.idToken === 'mock-id-token') return mockUser;
+  return userFromIdToken(session.idToken);
+}

--- a/src/aws-auth/cognitoClient.ts
+++ b/src/aws-auth/cognitoClient.ts
@@ -71,13 +71,18 @@ export async function signInWithPassword(
   password: string,
 ): Promise<AppSession> {
   if (isAwsAuthMock) {
+    const passwordMockUser: AppUser = {
+      ...mockUser,
+      email: email || mockUser.email,
+      auth_provider: 'password',
+    };
     const session: AppSession = {
       accessToken: 'mock-access-token',
       idToken: 'mock-id-token',
       refreshToken: 'mock-refresh-token',
       expiresAt: Date.now() + 60 * 60 * 1000,
     };
-    localStorage.setItem('runcount.auth.mock-user', JSON.stringify(mockUser));
+    localStorage.setItem('runcount.auth.mock-user', JSON.stringify(passwordMockUser));
     return session;
   }
 
@@ -188,6 +193,10 @@ export async function verifyEmailUpdate(
 }
 
 export function getUserFromPasswordSession(session: AppSession): AppUser {
-  if (session.idToken === 'mock-id-token') return mockUser;
+  if (session.idToken === 'mock-id-token') {
+    const raw = localStorage.getItem('runcount.auth.mock-user');
+    if (raw) return JSON.parse(raw) as AppUser;
+    return mockUser;
+  }
   return userFromIdToken(session.idToken);
 }

--- a/src/aws-auth/config.ts
+++ b/src/aws-auth/config.ts
@@ -29,6 +29,7 @@ export const cognitoConfig = {
 export const mockUser = {
   id: import.meta.env.VITE_AUTH_MOCK_SUB ?? 'mock-user-1',
   email: import.meta.env.VITE_AUTH_MOCK_EMAIL ?? 'mock@example.com',
+  auth_provider: 'password',
   created_at: new Date(0).toISOString(),
   user_metadata: {
     given_name: import.meta.env.VITE_AUTH_MOCK_GIVEN_NAME ?? 'Mock',

--- a/src/aws-auth/session.ts
+++ b/src/aws-auth/session.ts
@@ -55,7 +55,10 @@ export function getStoredMockUser(): AppUser | null {
 
 export async function startAwsSignIn(): Promise<void> {
   if (isAwsAuthMock) {
-    localStorage.setItem(MOCK_USER_STORAGE_KEY, JSON.stringify(mockUser));
+    localStorage.setItem(
+      MOCK_USER_STORAGE_KEY,
+      JSON.stringify({ ...mockUser, auth_provider: 'google' }),
+    );
     window.location.reload();
     return;
   }

--- a/src/aws-auth/tokens.test.ts
+++ b/src/aws-auth/tokens.test.ts
@@ -1,0 +1,48 @@
+import { userFromIdToken } from './tokens';
+
+function encodeJwtPayload(payload: Record<string, unknown>): string {
+  const encodedPayload = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
+  return `header.${encodedPayload}.signature`;
+}
+
+describe('userFromIdToken', () => {
+  test('marks Cognito password users as password provider', () => {
+    const user = userFromIdToken(
+      encodeJwtPayload({
+        sub: 'user-1',
+        email: 'player@example.com',
+        iat: 1760000000,
+      }),
+    );
+
+    expect(user.auth_provider).toBe('password');
+  });
+
+  test('marks Google users from Cognito identities claim', () => {
+    const user = userFromIdToken(
+      encodeJwtPayload({
+        sub: 'user-1',
+        email: 'player@example.com',
+        identities: [{ providerName: 'Google' }],
+      }),
+    );
+
+    expect(user.auth_provider).toBe('google');
+  });
+
+  test('marks Google users from Cognito username fallback', () => {
+    const user = userFromIdToken(
+      encodeJwtPayload({
+        sub: 'user-1',
+        email: 'player@example.com',
+        'cognito:username': 'Google_123456',
+      }),
+    );
+
+    expect(user.auth_provider).toBe('google');
+  });
+});

--- a/src/aws-auth/tokens.ts
+++ b/src/aws-auth/tokens.ts
@@ -10,6 +10,8 @@ interface CognitoUserClaims {
   given_name?: string;
   family_name?: string;
   name?: string;
+  identities?: unknown;
+  'cognito:username'?: string;
   iat?: number;
 }
 
@@ -24,6 +26,34 @@ function decodeJwt<T = unknown>(token: string): T {
   const [, payload] = token.split('.');
   const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
   return JSON.parse(atob(padded)) as T;
+}
+
+function getProviderFromIdentities(identities: unknown): string | undefined {
+  const parsedIdentities =
+    typeof identities === 'string' ? (JSON.parse(identities) as unknown) : identities;
+
+  if (!Array.isArray(parsedIdentities)) return undefined;
+
+  const [primaryIdentity] = parsedIdentities;
+  if (!primaryIdentity || typeof primaryIdentity !== 'object') return undefined;
+
+  const providerName = (primaryIdentity as { providerName?: unknown }).providerName;
+  return typeof providerName === 'string' ? providerName.toLowerCase() : undefined;
+}
+
+function getAuthProvider(claims: CognitoUserClaims): AppUser['auth_provider'] {
+  try {
+    const identityProvider = getProviderFromIdentities(claims.identities);
+    if (identityProvider) return identityProvider;
+  } catch {
+    return 'password';
+  }
+
+  if (claims['cognito:username']?.toLowerCase().startsWith('google_')) {
+    return 'google';
+  }
+
+  return 'password';
 }
 
 function toSession(res: TokenResponse, existingRefresh?: string): AppSession {
@@ -59,6 +89,7 @@ export function userFromIdToken(idToken: string): AppUser {
   return {
     id: claims.sub,
     email: claims.email,
+    auth_provider: getAuthProvider(claims),
     created_at: claims.iat ? new Date(claims.iat * 1000).toISOString() : undefined,
     user_metadata: {
       given_name: claims.given_name,

--- a/src/backend/awsBackend.test.ts
+++ b/src/backend/awsBackend.test.ts
@@ -1,0 +1,26 @@
+import { createAwsBackend } from './awsBackend';
+
+describe('createAwsBackend', () => {
+  test('omits account update capabilities when no auth actions are provided', () => {
+    const backend = createAwsBackend(vi.fn().mockResolvedValue('token'));
+
+    expect(backend.updateEmail).toBeUndefined();
+    expect(backend.updatePassword).toBeUndefined();
+    expect(backend.requiresCurrentPasswordForPasswordUpdate).toBeUndefined();
+  });
+
+  test('exposes password update capability when password auth actions are provided', async () => {
+    const updatePassword = vi.fn().mockResolvedValue(undefined);
+    const backend = createAwsBackend(vi.fn().mockResolvedValue('token'), {
+      updateEmail: vi.fn(),
+      verifyEmailUpdate: vi.fn(),
+      updatePassword,
+    });
+
+    await backend.updatePassword?.('NewStrongPass1!', 'CurrentPass1!');
+
+    expect(backend.updateEmail).toBeDefined();
+    expect(backend.requiresCurrentPasswordForPasswordUpdate).toBe(true);
+    expect(updatePassword).toHaveBeenCalledWith('CurrentPass1!', 'NewStrongPass1!');
+  });
+});

--- a/src/backend/awsBackend.ts
+++ b/src/backend/awsBackend.ts
@@ -11,7 +11,7 @@ import type { GameBackend } from './types';
 interface AwsBackendAuthActions {
   updateEmail: (email: string) => Promise<void>;
   verifyEmailUpdate: (code: string) => Promise<void>;
-  updatePassword: (currentPassword: string, password: string) => Promise<void>;
+  updatePassword?: (currentPassword: string, password: string) => Promise<void>;
 }
 
 export function createAwsBackend(
@@ -24,7 +24,7 @@ export function createAwsBackend(
     return token;
   };
 
-  return {
+  const backend: GameBackend = {
     async listGames() {
       return listGames(await requireToken());
     },
@@ -45,25 +45,28 @@ export function createAwsBackend(
       const currentUser = await getCurrentUser(await requireToken());
       return currentUser.stats;
     },
+  };
 
-    async updateEmail(email) {
-      if (!authActions) throw new Error('AWS account updates are not configured.');
+  if (authActions) {
+    backend.updateEmail = async (email) => {
       await authActions.updateEmail(email);
-    },
+    };
 
-    async verifyEmailUpdate(code) {
-      if (!authActions) throw new Error('AWS account updates are not configured.');
+    backend.verifyEmailUpdate = async (code) => {
       await authActions.verifyEmailUpdate(code);
-    },
+    };
+  }
 
-    async updatePassword(password, currentPassword) {
-      if (!authActions) throw new Error('AWS account updates are not configured.');
+  if (authActions?.updatePassword) {
+    backend.updatePassword = async (password, currentPassword) => {
       if (!currentPassword) {
         throw new Error('Enter your current password to change your password.');
       }
       await authActions.updatePassword(currentPassword, password);
-    },
+    };
 
-    requiresCurrentPasswordForPasswordUpdate: true,
-  };
+    backend.requiresCurrentPasswordForPasswordUpdate = true;
+  }
+
+  return backend;
 }

--- a/src/backend/awsBackend.ts
+++ b/src/backend/awsBackend.ts
@@ -8,7 +8,16 @@ import {
 
 import type { GameBackend } from './types';
 
-export function createAwsBackend(getIdToken: () => Promise<string | null>): GameBackend {
+interface AwsBackendAuthActions {
+  updateEmail: (email: string) => Promise<void>;
+  verifyEmailUpdate: (code: string) => Promise<void>;
+  updatePassword: (currentPassword: string, password: string) => Promise<void>;
+}
+
+export function createAwsBackend(
+  getIdToken: () => Promise<string | null>,
+  authActions?: AwsBackendAuthActions,
+): GameBackend {
   const requireToken = async () => {
     const token = await getIdToken();
     if (!token) throw new Error('You must be signed in to use cloud sync.');
@@ -36,5 +45,25 @@ export function createAwsBackend(getIdToken: () => Promise<string | null>): Game
       const currentUser = await getCurrentUser(await requireToken());
       return currentUser.stats;
     },
+
+    async updateEmail(email) {
+      if (!authActions) throw new Error('AWS account updates are not configured.');
+      await authActions.updateEmail(email);
+    },
+
+    async verifyEmailUpdate(code) {
+      if (!authActions) throw new Error('AWS account updates are not configured.');
+      await authActions.verifyEmailUpdate(code);
+    },
+
+    async updatePassword(password, currentPassword) {
+      if (!authActions) throw new Error('AWS account updates are not configured.');
+      if (!currentPassword) {
+        throw new Error('Enter your current password to change your password.');
+      }
+      await authActions.updatePassword(currentPassword, password);
+    },
+
+    requiresCurrentPasswordForPasswordUpdate: true,
   };
 }

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -17,7 +17,9 @@ export interface GameBackend {
   deleteGame: (gameId: string) => Promise<void>;
   getProfileStats: (user: AppUser) => Promise<ProfileStats>;
   updateEmail?: (email: string) => Promise<void>;
-  updatePassword?: (password: string) => Promise<void>;
+  verifyEmailUpdate?: (code: string) => Promise<void>;
+  updatePassword?: (password: string, currentPassword?: string) => Promise<void>;
+  requiresCurrentPasswordForPasswordUpdate?: boolean;
   subscribeToGames?: (
     user: AppUser | null,
     onChange: (event: { type: 'INSERT' | 'UPDATE' | 'DELETE'; game: GameData }) => void,

--- a/src/components/GameRouter.test.tsx
+++ b/src/components/GameRouter.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+
+import { GameRouter } from './GameRouter';
+
+import type { GameBackend } from '../backend/types';
+import type { AppUser } from '../types/auth';
+
+vi.mock('./GameSetup', () => ({
+  default: () => <div data-testid="game-setup">Game Setup</div>,
+}));
+
+vi.mock('./auth/UserProfile', () => ({
+  default: ({ user }: { user: AppUser }) => (
+    <div data-testid="user-profile">{user.email}</div>
+  ),
+}));
+
+vi.mock('./GameHistory/index', () => ({
+  default: () => <div data-testid="game-history">Game History</div>,
+}));
+
+vi.mock('./GameScoring/index', () => ({
+  default: () => <div data-testid="game-scoring">Game Scoring</div>,
+}));
+
+vi.mock('./GameStatistics', () => ({
+  default: () => <div data-testid="game-statistics">Game Statistics</div>,
+}));
+
+vi.mock('./Trends/index', () => ({
+  default: () => <div data-testid="trends">Trends</div>,
+}));
+
+const backend = {
+  listGames: vi.fn(),
+  getGame: vi.fn(),
+  saveGame: vi.fn(),
+  deleteGame: vi.fn(),
+  getProfileStats: vi.fn(),
+} as unknown as GameBackend;
+
+const baseProps = {
+  backend,
+  lastPlayers: [],
+  lastPlayerTargetScores: {},
+  lastBreakingPlayerId: 0,
+  lastShotClockSeconds: null,
+  onStartGame: vi.fn(),
+  players: [],
+  playerTargetScores: {},
+  gameId: null,
+  setGameId: vi.fn(),
+  breakingPlayerId: 0,
+  shotClockSeconds: null,
+  matchStartTime: null,
+  matchEndTime: null,
+  setMatchStartTime: vi.fn(),
+  setMatchEndTime: vi.fn(),
+  turnStartTime: null,
+  setTurnStartTime: vi.fn(),
+  ballsOnTable: 15,
+  setBallsOnTable: vi.fn(),
+  onFinishGame: vi.fn(),
+  onStartNewGame: vi.fn(),
+  onViewHistory: vi.fn(),
+  onGoToSetup: vi.fn(),
+  onViewTrends: vi.fn(),
+  onSignOut: vi.fn(),
+};
+
+describe('GameRouter', () => {
+  test('does not render profile with a null user', () => {
+    render(<GameRouter {...baseProps} gameState="profile" user={null} />);
+
+    expect(screen.getByTestId('game-setup')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-profile')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/GameRouter.tsx
+++ b/src/components/GameRouter.tsx
@@ -85,17 +85,19 @@ export const GameRouter: FC<GameRouterProps> = ({
   onViewTrends,
   onSignOut,
 }) => {
+  const renderSetup = () => (
+    <GameSetup
+      startGame={onStartGame}
+      lastPlayers={lastPlayers}
+      lastPlayerTargetScores={lastPlayerTargetScores}
+      lastBreakingPlayerId={lastBreakingPlayerId}
+      lastShotClockSeconds={lastShotClockSeconds}
+    />
+  );
+
   switch (gameState) {
     case 'setup':
-      return (
-        <GameSetup
-          startGame={onStartGame}
-          lastPlayers={lastPlayers}
-          lastPlayerTargetScores={lastPlayerTargetScores}
-          lastBreakingPlayerId={lastBreakingPlayerId}
-          lastShotClockSeconds={lastShotClockSeconds}
-        />
-      );
+      return renderSetup();
     case 'scoring':
       return (
         <GameScoring
@@ -140,10 +142,11 @@ export const GameRouter: FC<GameRouterProps> = ({
     case 'trends':
       return <TrendsPage backend={backend} user={user} onStartNewGame={onGoToSetup} />;
     case 'profile':
+      if (!user) return renderSetup();
       return (
-        <UserProfile backend={backend} user={user!} onSignOut={onSignOut} showPageTitle />
+        <UserProfile backend={backend} user={user} onSignOut={onSignOut} showPageTitle />
       );
     default:
-      return <GameSetup startGame={onStartGame} />;
+      return renderSetup();
   }
 };

--- a/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
@@ -125,5 +125,5 @@ describe('GameScoring consecutive foul flow', () => {
       expect(screen.getByTestId('player-score-1')).toHaveTextContent('0');
       expect(screen.getByText('Re-Break')).toBeInTheDocument();
     });
-  });
+  }, 15000);
 });

--- a/src/components/GameScoring/hooks/__tests__/useGameActions.simulation.test.tsx
+++ b/src/components/GameScoring/hooks/__tests__/useGameActions.simulation.test.tsx
@@ -268,5 +268,5 @@ describe('useGameActions generated simulations', () => {
       ).not.toBeNull();
       assertSimulationInvariants(result.current);
     }
-  });
+  }, 15000);
 });

--- a/src/components/auth/Auth.tsx
+++ b/src/components/auth/Auth.tsx
@@ -8,8 +8,18 @@ import SignUp from './SignUp';
 
 export type AuthTab = 'login' | 'signup' | 'reset-password';
 
+export interface AwsAuthOperations {
+  signInWithPassword: (email: string, password: string) => Promise<void>;
+  signInWithGoogle: () => Promise<void>;
+  signUp: (email: string, password: string) => Promise<{ userConfirmed: boolean }>;
+  confirmSignUp: (email: string, code: string) => Promise<void>;
+  forgotPassword: (email: string) => Promise<void>;
+  confirmForgotPassword: (email: string, code: string, password: string) => Promise<void>;
+}
+
 interface AuthProps {
-  supabase: SupabaseClient;
+  supabase?: SupabaseClient;
+  awsAuth?: AwsAuthOperations;
   /**
    * Active tab is owned by the parent (AuthModal) so it can also drive
    * the per-tab modal title and conditionally hide the benefits panel
@@ -39,6 +49,7 @@ const TABS: TabDefinition[] = [
 
 const Auth: React.FC<AuthProps> = ({
   supabase,
+  awsAuth,
   activeTab,
   onTabChange,
   onAuthSuccess,
@@ -76,15 +87,20 @@ const Auth: React.FC<AuthProps> = ({
         {activeTab === 'login' && (
           <Login
             supabase={supabase}
+            awsAuth={awsAuth}
             onSuccess={onAuthSuccess}
             onForgotPassword={() => onTabChange('reset-password')}
           />
         )}
         {activeTab === 'signup' && (
-          <SignUp supabase={supabase} onSuccess={onAuthSuccess} />
+          <SignUp supabase={supabase} awsAuth={awsAuth} onSuccess={onAuthSuccess} />
         )}
         {activeTab === 'reset-password' && (
-          <ResetPassword supabase={supabase} onSuccess={onAuthSuccess} />
+          <ResetPassword
+            supabase={supabase}
+            awsAuth={awsAuth}
+            onSuccess={onAuthSuccess}
+          />
         )}
       </div>
     </div>

--- a/src/components/auth/Login.test.tsx
+++ b/src/components/auth/Login.test.tsx
@@ -86,4 +86,59 @@ describe('Login', () => {
 
     expect(await screen.findByText('Apple OAuth is not configured')).toBeInTheDocument();
   });
+
+  test('submits AWS email login credentials and closes on success', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn().mockResolvedValue(undefined),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn(),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<Login awsAuth={awsAuth} onSuccess={onSuccess} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(awsAuth.signInWithPassword).toHaveBeenCalledWith(
+        'player@example.com',
+        'secret123',
+      );
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: /^apple$/i })).not.toBeInTheDocument();
+  });
+
+  test('shows an AWS login error', async () => {
+    const awsAuth = {
+      signInWithPassword: vi
+        .fn()
+        .mockRejectedValue(new Error('Incorrect username or password')),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn(),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<Login awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'wrong-password' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText('Incorrect username or password')).toBeInTheDocument();
+  });
 });

--- a/src/components/auth/Login.tsx
+++ b/src/components/auth/Login.tsx
@@ -4,8 +4,11 @@ import { type SupabaseClient } from '@supabase/supabase-js';
 
 import { getAuthCallbackUrl } from '../../utils/authRedirect';
 
+import type { AwsAuthOperations } from './Auth';
+
 interface LoginProps {
-  supabase: SupabaseClient;
+  supabase?: SupabaseClient;
+  awsAuth?: AwsAuthOperations;
   onSuccess?: () => void;
   /**
    * Triggered by the "Forgot password?" link below the password field.
@@ -22,7 +25,12 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
-const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) => {
+const Login: React.FC<LoginProps> = ({
+  supabase,
+  awsAuth,
+  onSuccess,
+  onForgotPassword,
+}) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -35,12 +43,18 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) 
       setLoading(true);
       setError(null);
 
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+      if (awsAuth) {
+        await awsAuth.signInWithPassword(email, password);
+      } else if (supabase) {
+        const { error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
 
       if (onSuccess) {
         onSuccess();
@@ -57,14 +71,23 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) 
       setLoading(true);
       setError(null);
 
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider,
-        options: {
-          redirectTo: getAuthCallbackUrl(),
-        },
-      });
+      if (awsAuth) {
+        if (provider !== 'google') {
+          throw new Error('Apple login is not configured for AWS mode.');
+        }
+        await awsAuth.signInWithGoogle();
+      } else if (supabase) {
+        const { error } = await supabase.auth.signInWithOAuth({
+          provider,
+          options: {
+            redirectTo: getAuthCallbackUrl(),
+          },
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
     } catch (error) {
       setError(getErrorMessage(error, `An error occurred during ${provider} login`));
     } finally {
@@ -178,7 +201,7 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) 
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className={awsAuth ? 'grid grid-cols-1 gap-3' : 'grid grid-cols-2 gap-3'}>
         <button
           type="button"
           onClick={() => handleSocialLogin('google')}
@@ -194,21 +217,23 @@ const Login: React.FC<LoginProps> = ({ supabase, onSuccess, onForgotPassword }) 
           </svg>
           <span className="ml-2">Google</span>
         </button>
-        <button
-          type="button"
-          onClick={() => handleSocialLogin('apple')}
-          className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-          disabled={loading}
-        >
-          <svg
-            className="h-5 w-5 text-gray-500 dark:text-gray-300"
-            viewBox="0 0 24 24"
-            fill="currentColor"
+        {!awsAuth && (
+          <button
+            type="button"
+            onClick={() => handleSocialLogin('apple')}
+            className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+            disabled={loading}
           >
-            <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701z" />
-          </svg>
-          <span className="ml-2">Apple</span>
-        </button>
+            <svg
+              className="h-5 w-5 text-gray-500 dark:text-gray-300"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+            >
+              <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701z" />
+            </svg>
+            <span className="ml-2">Apple</span>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/auth/ResetPassword.test.tsx
+++ b/src/components/auth/ResetPassword.test.tsx
@@ -75,4 +75,69 @@ describe('ResetPassword', () => {
     expect(await screen.findByText('Password updated successfully!')).toBeInTheDocument();
     expect(window.location.hash).toBe('');
   });
+
+  test('sends and confirms an AWS password reset code', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn().mockResolvedValue(undefined),
+      confirmForgotPassword: vi.fn().mockResolvedValue(undefined),
+    };
+
+    render(<ResetPassword awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await waitFor(() => {
+      expect(awsAuth.forgotPassword).toHaveBeenCalledWith('player@example.com');
+    });
+    expect(
+      await screen.findByText('Password reset code sent to your email!'),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/verification code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'newsecret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'newsecret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    await waitFor(() => {
+      expect(awsAuth.confirmForgotPassword).toHaveBeenCalledWith(
+        'player@example.com',
+        '123456',
+        'newsecret123',
+      );
+    });
+    expect(await screen.findByText('Password updated successfully!')).toBeInTheDocument();
+  });
+
+  test('shows AWS reset errors', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn().mockRejectedValue(new Error('User not found')),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<ResetPassword awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'missing@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    expect(await screen.findByText('User not found')).toBeInTheDocument();
+  });
 });

--- a/src/components/auth/ResetPassword.test.tsx
+++ b/src/components/auth/ResetPassword.test.tsx
@@ -104,10 +104,10 @@ describe('ResetPassword', () => {
       target: { value: '123456' },
     });
     fireEvent.change(screen.getByLabelText(/new password/i), {
-      target: { value: 'newsecret123' },
+      target: { value: 'NewStrongPass1!' },
     });
     fireEvent.change(screen.getByLabelText(/confirm password/i), {
-      target: { value: 'newsecret123' },
+      target: { value: 'NewStrongPass1!' },
     });
     fireEvent.click(screen.getByRole('button', { name: /update password/i }));
 
@@ -115,10 +115,46 @@ describe('ResetPassword', () => {
       expect(awsAuth.confirmForgotPassword).toHaveBeenCalledWith(
         'player@example.com',
         '123456',
-        'newsecret123',
+        'NewStrongPass1!',
       );
     });
     expect(await screen.findByText('Password updated successfully!')).toBeInTheDocument();
+  });
+
+  test('blocks AWS password reset before submit when the password misses Cognito policy', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn().mockResolvedValue(undefined),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<ResetPassword awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send reset link/i }));
+
+    await screen.findByText('Password reset code sent to your email!');
+
+    fireEvent.change(screen.getByLabelText(/verification code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.change(screen.getByLabelText(/new password/i), {
+      target: { value: 'newsecret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'newsecret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(awsAuth.confirmForgotPassword).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Use at least 8 characters with uppercase, lowercase, a number, and a symbol.',
+    );
   });
 
   test('shows AWS reset errors', async () => {

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -2,6 +2,12 @@ import React, { useState } from 'react';
 
 import { type SupabaseClient } from '@supabase/supabase-js';
 
+import {
+  getPasswordPolicyError,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_POLICY_MESSAGE,
+} from './passwordPolicy';
+
 import type { AwsAuthOperations } from './Auth';
 
 interface ResetPasswordProps {
@@ -82,6 +88,14 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({
       return;
     }
 
+    if (awsAuth) {
+      const passwordPolicyError = getPasswordPolicyError(newPassword);
+      if (passwordPolicyError) {
+        setError(passwordPolicyError);
+        return;
+      }
+    }
+
     try {
       setLoading(true);
       setError(null);
@@ -120,7 +134,10 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({
   return (
     <div className="space-y-5">
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-lg text-sm animate-fade-in">
+        <div
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-lg text-sm animate-fade-in"
+        >
           {error}
         </div>
       )}
@@ -169,11 +186,20 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               required
-              minLength={6}
+              minLength={awsAuth ? PASSWORD_MIN_LENGTH : 6}
+              aria-describedby={awsAuth ? 'reset-password-help' : undefined}
               className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
               placeholder="Enter your new password"
               disabled={loading}
             />
+            {awsAuth && (
+              <p
+                id="reset-password-help"
+                className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+              >
+                {PASSWORD_POLICY_MESSAGE}
+              </p>
+            )}
           </div>
 
           <div>

--- a/src/components/auth/ResetPassword.tsx
+++ b/src/components/auth/ResetPassword.tsx
@@ -2,8 +2,11 @@ import React, { useState } from 'react';
 
 import { type SupabaseClient } from '@supabase/supabase-js';
 
+import type { AwsAuthOperations } from './Auth';
+
 interface ResetPasswordProps {
-  supabase: SupabaseClient;
+  supabase?: SupabaseClient;
+  awsAuth?: AwsAuthOperations;
   onSuccess?: () => void;
 }
 
@@ -14,8 +17,14 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
-const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) => {
+const ResetPassword: React.FC<ResetPasswordProps> = ({
+  supabase,
+  awsAuth,
+  onSuccess,
+}) => {
   const [email, setEmail] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [codeSent, setCodeSent] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -24,7 +33,7 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const urlHash = window.location.hash;
-  const isResetting = urlHash.includes('type=recovery');
+  const isResetting = awsAuth ? codeSent : urlHash.includes('type=recovery');
 
   const handleSendResetLink = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,15 +43,26 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
       setError(null);
       setMessage(null);
 
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}`,
-      });
+      if (awsAuth) {
+        await awsAuth.forgotPassword(email);
+        setCodeSent(true);
+      } else if (supabase) {
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          redirectTo: `${window.location.origin}`,
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
 
-      setMessage('Password reset instructions sent to your email!');
+      setMessage(
+        awsAuth
+          ? 'Password reset code sent to your email!'
+          : 'Password reset instructions sent to your email!',
+      );
 
-      if (onSuccess) {
+      if (!awsAuth && onSuccess) {
         setTimeout(() => {
           onSuccess();
         }, 2000);
@@ -67,15 +87,23 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
       setError(null);
       setMessage(null);
 
-      const { error } = await supabase.auth.updateUser({
-        password: newPassword,
-      });
+      if (awsAuth) {
+        await awsAuth.confirmForgotPassword(email, verificationCode, newPassword);
+      } else if (supabase) {
+        const { error } = await supabase.auth.updateUser({
+          password: newPassword,
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
 
       setMessage('Password updated successfully!');
 
-      window.history.replaceState(null, '', window.location.pathname);
+      if (!awsAuth) {
+        window.history.replaceState(null, '', window.location.pathname);
+      }
 
       if (onSuccess) {
         setTimeout(() => {
@@ -105,6 +133,29 @@ const ResetPassword: React.FC<ResetPasswordProps> = ({ supabase, onSuccess }) =>
 
       {isResetting ? (
         <form onSubmit={handleResetPassword} className="space-y-5">
+          {awsAuth && (
+            <div>
+              <label
+                htmlFor="reset-verification-code"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Verification code
+              </label>
+              <input
+                id="reset-verification-code"
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value)}
+                required
+                className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+                placeholder="Enter the code from your email"
+                disabled={loading}
+              />
+            </div>
+          )}
+
           <div>
             <label
               htmlFor="new-password"

--- a/src/components/auth/SignUp.test.tsx
+++ b/src/components/auth/SignUp.test.tsx
@@ -79,15 +79,15 @@ describe('SignUp', () => {
       target: { value: 'player@example.com' },
     });
     fireEvent.change(screen.getByLabelText(/^password$/i), {
-      target: { value: 'secret123' },
+      target: { value: 'StrongPass1!' },
     });
     fireEvent.change(screen.getByLabelText(/confirm password/i), {
-      target: { value: 'secret123' },
+      target: { value: 'StrongPass1!' },
     });
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
     await waitFor(() => {
-      expect(awsAuth.signUp).toHaveBeenCalledWith('player@example.com', 'secret123');
+      expect(awsAuth.signUp).toHaveBeenCalledWith('player@example.com', 'StrongPass1!');
     });
     expect(
       await screen.findByText('Check your email for the verification code.'),
@@ -106,6 +106,35 @@ describe('SignUp', () => {
     ).toBeInTheDocument();
   });
 
+  test('blocks AWS signup before submit when the password misses Cognito policy', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn(),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn(),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<SignUp awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/^email$/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(awsAuth.signUp).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Use at least 8 characters with uppercase, lowercase, a number, and a symbol.',
+    );
+  });
+
   test('shows AWS signup errors', async () => {
     const awsAuth = {
       signInWithPassword: vi.fn(),
@@ -122,10 +151,10 @@ describe('SignUp', () => {
       target: { value: 'player@example.com' },
     });
     fireEvent.change(screen.getByLabelText(/^password$/i), {
-      target: { value: 'secret123' },
+      target: { value: 'StrongPass1!' },
     });
     fireEvent.change(screen.getByLabelText(/confirm password/i), {
-      target: { value: 'secret123' },
+      target: { value: 'StrongPass1!' },
     });
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 

--- a/src/components/auth/SignUp.test.tsx
+++ b/src/components/auth/SignUp.test.tsx
@@ -62,4 +62,73 @@ describe('SignUp', () => {
       });
     });
   });
+
+  test('starts AWS signup and confirms the emailed verification code', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn().mockResolvedValue({ userConfirmed: false }),
+      confirmSignUp: vi.fn().mockResolvedValue(undefined),
+      forgotPassword: vi.fn(),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<SignUp awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/^email$/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(awsAuth.signUp).toHaveBeenCalledWith('player@example.com', 'secret123');
+    });
+    expect(
+      await screen.findByText('Check your email for the verification code.'),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/verification code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /verify email/i }));
+
+    await waitFor(() => {
+      expect(awsAuth.confirmSignUp).toHaveBeenCalledWith('player@example.com', '123456');
+    });
+    expect(
+      await screen.findByText('Email verified. You can sign in now.'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows AWS signup errors', async () => {
+    const awsAuth = {
+      signInWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      signUp: vi.fn().mockRejectedValue(new Error('User already exists')),
+      confirmSignUp: vi.fn(),
+      forgotPassword: vi.fn(),
+      confirmForgotPassword: vi.fn(),
+    };
+
+    render(<SignUp awsAuth={awsAuth} />);
+
+    fireEvent.change(screen.getByLabelText(/^email$/i), {
+      target: { value: 'player@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+
+    expect(await screen.findByText('User already exists')).toBeInTheDocument();
+  });
 });

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -4,8 +4,11 @@ import { type SupabaseClient } from '@supabase/supabase-js';
 
 import { getAuthCallbackUrl } from '../../utils/authRedirect';
 
+import type { AwsAuthOperations } from './Auth';
+
 interface SignUpProps {
-  supabase: SupabaseClient;
+  supabase?: SupabaseClient;
+  awsAuth?: AwsAuthOperations;
   onSuccess?: () => void;
 }
 
@@ -16,10 +19,12 @@ const getErrorMessage = (error: unknown, fallback: string) => {
   return fallback;
 };
 
-const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
+const SignUp: React.FC<SignUpProps> = ({ supabase, awsAuth, onSuccess }) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [awaitingConfirmation, setAwaitingConfirmation] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -37,15 +42,26 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
       setError(null);
       setMessage(null);
 
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          emailRedirectTo: getAuthCallbackUrl(),
-        },
-      });
+      if (awsAuth) {
+        const result = await awsAuth.signUp(email, password);
+        if (!result.userConfirmed) {
+          setAwaitingConfirmation(true);
+          setMessage('Check your email for the verification code.');
+          return;
+        }
+      } else if (supabase) {
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: getAuthCallbackUrl(),
+          },
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
 
       setMessage('Check your email for the confirmation link!');
 
@@ -59,19 +75,51 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
     }
   };
 
+  const handleConfirmSignUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      setLoading(true);
+      setError(null);
+      setMessage(null);
+
+      if (!awsAuth) throw new Error('Cognito confirmation is not configured.');
+      await awsAuth.confirmSignUp(email, verificationCode);
+
+      setMessage('Email verified. You can sign in now.');
+      setAwaitingConfirmation(false);
+      setPassword('');
+      setConfirmPassword('');
+      setVerificationCode('');
+    } catch (error) {
+      setError(getErrorMessage(error, 'An error occurred during verification'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleSocialSignUp = async (provider: 'google' | 'apple') => {
     try {
       setLoading(true);
       setError(null);
 
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider,
-        options: {
-          redirectTo: getAuthCallbackUrl(),
-        },
-      });
+      if (awsAuth) {
+        if (provider !== 'google') {
+          throw new Error('Apple sign up is not configured for AWS mode.');
+        }
+        await awsAuth.signInWithGoogle();
+      } else if (supabase) {
+        const { error } = await supabase.auth.signInWithOAuth({
+          provider,
+          options: {
+            redirectTo: getAuthCallbackUrl(),
+          },
+        });
 
-      if (error) throw error;
+        if (error) throw error;
+      } else {
+        throw new Error('Authentication is not configured.');
+      }
     } catch (error) {
       setError(getErrorMessage(error, `An error occurred during ${provider} sign up`));
     } finally {
@@ -93,143 +141,191 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, onSuccess }) => {
         </div>
       )}
 
-      <form onSubmit={handleSignUp} className="space-y-5">
-        <div>
-          <label
-            htmlFor="sign-up-email"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-          >
-            Email
-          </label>
-          <input
-            id="sign-up-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
-            placeholder="Enter your email"
-            disabled={loading}
-          />
-        </div>
+      {awaitingConfirmation ? (
+        <form onSubmit={handleConfirmSignUp} className="space-y-5">
+          <div>
+            <label
+              htmlFor="verification-code"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Verification code
+            </label>
+            <input
+              id="verification-code"
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              value={verificationCode}
+              onChange={(e) => setVerificationCode(e.target.value)}
+              required
+              className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+              placeholder="Enter the code from your email"
+              disabled={loading}
+            />
+          </div>
 
-        <div>
-          <label
-            htmlFor="sign-up-password"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
-          >
-            Password
-          </label>
-          <input
-            id="sign-up-password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={6}
-            className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
-            placeholder="Create a password"
+          <button
+            type="submit"
+            className="w-full bg-blue-600 dark:bg-blue-700 text-white py-2.5 px-4 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
             disabled={loading}
-          />
-        </div>
-
-        <div>
-          <label
-            htmlFor="confirm-password"
-            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
           >
-            Confirm Password
-          </label>
-          <input
-            id="confirm-password"
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            required
-            className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
-            placeholder="Confirm your password"
-            disabled={loading}
-          />
-        </div>
+            {loading ? 'Verifying...' : 'Verify Email'}
+          </button>
 
-        <button
-          type="submit"
-          className="w-full bg-blue-600 dark:bg-blue-700 text-white py-2.5 px-4 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
-          disabled={loading}
-        >
-          {loading ? (
-            <span className="flex items-center justify-center">
+          <button
+            type="button"
+            onClick={() => setAwaitingConfirmation(false)}
+            className="w-full text-sm font-medium text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
+            disabled={loading}
+          >
+            Edit signup details
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={handleSignUp} className="space-y-5">
+          <div>
+            <label
+              htmlFor="sign-up-email"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Email
+            </label>
+            <input
+              id="sign-up-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+              placeholder="Enter your email"
+              disabled={loading}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="sign-up-password"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Password
+            </label>
+            <input
+              id="sign-up-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+              placeholder="Create a password"
+              disabled={loading}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="confirm-password"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              Confirm Password
+            </label>
+            <input
+              id="confirm-password"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
+              placeholder="Confirm your password"
+              disabled={loading}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="w-full bg-blue-600 dark:bg-blue-700 text-white py-2.5 px-4 rounded-lg hover:bg-blue-700 dark:hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+            disabled={loading}
+          >
+            {loading ? (
+              <span className="flex items-center justify-center">
+                <svg
+                  className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                Creating account...
+              </span>
+            ) : (
+              'Create Account'
+            )}
+          </button>
+        </form>
+      )}
+
+      {!awaitingConfirmation && (
+        <>
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">
+                Or continue with
+              </span>
+            </div>
+          </div>
+
+          <div className={awsAuth ? 'grid grid-cols-1 gap-3' : 'grid grid-cols-2 gap-3'}>
+            <button
+              type="button"
+              onClick={() => handleSocialSignUp('google')}
+              className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+              disabled={loading}
+            >
               <svg
-                className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
+                className="h-5 w-5 text-gray-500 dark:text-gray-300"
                 viewBox="0 0 24 24"
+                fill="currentColor"
               >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                ></circle>
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                ></path>
+                <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
               </svg>
-              Creating account...
-            </span>
-          ) : (
-            'Create Account'
-          )}
-        </button>
-      </form>
-
-      <div className="relative">
-        <div className="absolute inset-0 flex items-center">
-          <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
-        </div>
-        <div className="relative flex justify-center text-sm">
-          <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">
-            Or continue with
-          </span>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-3">
-        <button
-          type="button"
-          onClick={() => handleSocialSignUp('google')}
-          className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-          disabled={loading}
-        >
-          <svg
-            className="h-5 w-5 text-gray-500 dark:text-gray-300"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
-          </svg>
-          <span className="ml-2">Google</span>
-        </button>
-        <button
-          type="button"
-          onClick={() => handleSocialSignUp('apple')}
-          className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
-          disabled={loading}
-        >
-          <svg
-            className="h-5 w-5 text-gray-500 dark:text-gray-300"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701z" />
-          </svg>
-          <span className="ml-2">Apple</span>
-        </button>
-      </div>
+              <span className="ml-2">Google</span>
+            </button>
+            {!awsAuth && (
+              <button
+                type="button"
+                onClick={() => handleSocialSignUp('apple')}
+                className="w-full inline-flex justify-center items-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-700 text-sm font-medium text-gray-700 dark:text-white hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-200"
+                disabled={loading}
+              >
+                <svg
+                  className="h-5 w-5 text-gray-500 dark:text-gray-300"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                >
+                  <path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701z" />
+                </svg>
+                <span className="ml-2">Apple</span>
+              </button>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -4,6 +4,12 @@ import { type SupabaseClient } from '@supabase/supabase-js';
 
 import { getAuthCallbackUrl } from '../../utils/authRedirect';
 
+import {
+  getPasswordPolicyError,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_POLICY_MESSAGE,
+} from './passwordPolicy';
+
 import type { AwsAuthOperations } from './Auth';
 
 interface SignUpProps {
@@ -35,6 +41,14 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, awsAuth, onSuccess }) => {
     if (password !== confirmPassword) {
       setError("Passwords don't match");
       return;
+    }
+
+    if (awsAuth) {
+      const passwordPolicyError = getPasswordPolicyError(password);
+      if (passwordPolicyError) {
+        setError(passwordPolicyError);
+        return;
+      }
     }
 
     try {
@@ -130,7 +144,10 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, awsAuth, onSuccess }) => {
   return (
     <div className="space-y-5">
       {error && (
-        <div className="bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-lg text-sm animate-fade-in">
+        <div
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/50 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-lg text-sm animate-fade-in"
+        >
           {error}
         </div>
       )}
@@ -215,11 +232,20 @@ const SignUp: React.FC<SignUpProps> = ({ supabase, awsAuth, onSuccess }) => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              minLength={6}
+              minLength={awsAuth ? PASSWORD_MIN_LENGTH : 6}
+              aria-describedby={awsAuth ? 'sign-up-password-help' : undefined}
               className="w-full px-4 py-2.5 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
               placeholder="Create a password"
               disabled={loading}
             />
+            {awsAuth && (
+              <p
+                id="sign-up-password-help"
+                className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+              >
+                {PASSWORD_POLICY_MESSAGE}
+              </p>
+            )}
           </div>
 
           <div>

--- a/src/components/auth/UserProfile.test.tsx
+++ b/src/components/auth/UserProfile.test.tsx
@@ -46,4 +46,18 @@ describe('UserProfile', () => {
       'Use at least 8 characters with uppercase, lowercase, a number, and a symbol.',
     );
   });
+
+  test('does not render account update forms when backend does not expose them', async () => {
+    const backend = buildBackend();
+
+    render(<UserProfile backend={backend} user={user} onSignOut={vi.fn()} />);
+
+    expect(await screen.findByText('Never')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /update email/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /update password/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/auth/UserProfile.test.tsx
+++ b/src/components/auth/UserProfile.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import UserProfile from './UserProfile';
+
+import type { GameBackend } from '../../backend/types';
+import type { AppUser } from '../../types/auth';
+
+describe('UserProfile', () => {
+  const user: AppUser = {
+    id: 'user-1',
+    email: 'player@example.com',
+    created_at: '2026-01-01T00:00:00.000Z',
+  };
+
+  const buildBackend = (overrides: Partial<GameBackend> = {}): GameBackend => ({
+    listGames: vi.fn().mockResolvedValue([]),
+    getGame: vi.fn().mockResolvedValue(null),
+    saveGame: vi.fn().mockResolvedValue(undefined),
+    deleteGame: vi.fn().mockResolvedValue(undefined),
+    getProfileStats: vi.fn().mockResolvedValue({ totalGames: 0, lastGameDate: null }),
+    ...overrides,
+  });
+
+  test('blocks Cognito password updates before submit when the password misses policy', async () => {
+    const updatePassword = vi.fn();
+    const backend = buildBackend({
+      updatePassword,
+      requiresCurrentPasswordForPasswordUpdate: true,
+    });
+
+    render(<UserProfile backend={backend} user={user} onSignOut={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/current password/i), {
+      target: { value: 'CurrentPass1!' },
+    });
+    fireEvent.change(screen.getByLabelText(/^new password$/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm new password/i), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /update password/i }));
+
+    expect(updatePassword).not.toHaveBeenCalled();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Use at least 8 characters with uppercase, lowercase, a number, and a symbol.',
+    );
+  });
+});

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -139,6 +139,9 @@ const UserProfile: React.FC<UserProfileProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
   const [newEmail, setNewEmail] = useState('');
+  const [emailVerificationCode, setEmailVerificationCode] = useState('');
+  const [awaitingEmailVerification, setAwaitingEmailVerification] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
@@ -165,8 +168,40 @@ const UserProfile: React.FC<UserProfileProps> = ({
       }
       await backend.updateEmail(newEmail);
 
-      setMessage('Email update initiated. Check your new email for confirmation!');
+      setMessage(
+        backend.verifyEmailUpdate
+          ? 'Email update initiated. Enter the code sent to your new email.'
+          : 'Email update initiated. Check your new email for confirmation!',
+      );
+      setAwaitingEmailVerification(Boolean(backend.verifyEmailUpdate));
       setNewEmail('');
+      setShowSuccessAnimation(true);
+      setTimeout(() => setShowSuccessAnimation(false), 2000);
+    } catch (error) {
+      setError(getErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyEmailUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      setLoading(true);
+      setError(null);
+      setMessage(null);
+
+      if (!backend.verifyEmailUpdate) {
+        throw new Error('Email verification is not configured.');
+      }
+      await backend.verifyEmailUpdate(emailVerificationCode);
+
+      setMessage(
+        'Email verified successfully. Sign out and back in if it is not refreshed yet.',
+      );
+      setEmailVerificationCode('');
+      setAwaitingEmailVerification(false);
       setShowSuccessAnimation(true);
       setTimeout(() => setShowSuccessAnimation(false), 2000);
     } catch (error) {
@@ -192,9 +227,10 @@ const UserProfile: React.FC<UserProfileProps> = ({
       if (!backend.updatePassword) {
         throw new Error('Password updates are part of the Phase 2 Cognito signup work.');
       }
-      await backend.updatePassword(newPassword);
+      await backend.updatePassword(newPassword, currentPassword);
 
       setMessage('Password updated successfully!');
+      setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');
       setShowSuccessAnimation(true);
@@ -297,12 +333,69 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 </button>
               </div>
             </form>
+
+            {awaitingEmailVerification && backend.verifyEmailUpdate && (
+              <form
+                onSubmit={handleVerifyEmailUpdate}
+                className="mt-4 border-t border-gray-100 dark:border-gray-700 pt-4 space-y-3"
+              >
+                <div>
+                  <label
+                    htmlFor="email-verification-code"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                  >
+                    Verification code
+                  </label>
+                  <input
+                    id="email-verification-code"
+                    type="text"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    value={emailVerificationCode}
+                    onChange={(e) => setEmailVerificationCode(e.target.value)}
+                    required
+                    disabled={loading}
+                    placeholder="Enter the code from your new email"
+                    className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
+                  />
+                </div>
+                <div className="flex justify-end">
+                  <button
+                    type="submit"
+                    disabled={loading || !emailVerificationCode}
+                    className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {loading && <SubmitSpinner />}
+                    {loading ? 'Verifying…' : 'Verify email'}
+                  </button>
+                </div>
+              </form>
+            )}
           </SectionCard>
         )}
 
         {canUpdatePassword && (
           <SectionCard heading="Change password">
             <form onSubmit={handleUpdatePassword} className="space-y-3">
+              {backend.requiresCurrentPasswordForPasswordUpdate && (
+                <div>
+                  <label
+                    htmlFor="current-password"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+                  >
+                    Current password
+                  </label>
+                  <input
+                    id="current-password"
+                    type="password"
+                    value={currentPassword}
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    required
+                    disabled={loading}
+                    className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
+                  />
+                </div>
+              )}
               <div>
                 <label
                   htmlFor="new-password"
@@ -340,7 +433,12 @@ const UserProfile: React.FC<UserProfileProps> = ({
               <div className="flex justify-end">
                 <button
                   type="submit"
-                  disabled={loading || !newPassword || !confirmPassword}
+                  disabled={
+                    loading ||
+                    !newPassword ||
+                    !confirmPassword ||
+                    (backend.requiresCurrentPasswordForPasswordUpdate && !currentPassword)
+                  }
                   className="inline-flex items-center justify-center rounded-md bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {loading && <SubmitSpinner />}

--- a/src/components/auth/UserProfile.tsx
+++ b/src/components/auth/UserProfile.tsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from 'react';
 
 import { formatGameDateTime } from '../../utils/formatGameDate';
 
+import {
+  getPasswordPolicyError,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_POLICY_MESSAGE,
+} from './passwordPolicy';
+
 import type { GameBackend } from '../../backend/types';
 import type { AppUser } from '../../types/auth';
 
@@ -154,6 +160,9 @@ const UserProfile: React.FC<UserProfileProps> = ({
   } = useProfileStats(backend, user);
   const canUpdateEmail = Boolean(backend.updateEmail);
   const canUpdatePassword = Boolean(backend.updatePassword);
+  const usesCognitoPasswordPolicy = Boolean(
+    backend.requiresCurrentPasswordForPasswordUpdate,
+  );
 
   const handleUpdateEmail = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -217,6 +226,14 @@ const UserProfile: React.FC<UserProfileProps> = ({
     if (newPassword !== confirmPassword) {
       setError("Passwords don't match");
       return;
+    }
+
+    if (usesCognitoPasswordPolicy) {
+      const passwordPolicyError = getPasswordPolicyError(newPassword);
+      if (passwordPolicyError) {
+        setError(passwordPolicyError);
+        return;
+      }
     }
 
     try {
@@ -409,9 +426,21 @@ const UserProfile: React.FC<UserProfileProps> = ({
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
                   required
+                  minLength={usesCognitoPasswordPolicy ? PASSWORD_MIN_LENGTH : undefined}
+                  aria-describedby={
+                    usesCognitoPasswordPolicy ? 'profile-password-help' : undefined
+                  }
                   disabled={loading}
                   className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors disabled:opacity-50"
                 />
+                {usesCognitoPasswordPolicy && (
+                  <p
+                    id="profile-password-help"
+                    className="mt-1 text-xs text-gray-500 dark:text-gray-400"
+                  >
+                    {PASSWORD_POLICY_MESSAGE}
+                  </p>
+                )}
               </div>
               <div>
                 <label

--- a/src/components/auth/passwordPolicy.ts
+++ b/src/components/auth/passwordPolicy.ts
@@ -1,0 +1,14 @@
+export const PASSWORD_MIN_LENGTH = 8;
+
+export const PASSWORD_POLICY_MESSAGE =
+  'Use at least 8 characters with uppercase, lowercase, a number, and a symbol.';
+
+export const getPasswordPolicyError = (password: string): string | null => {
+  if (password.length < PASSWORD_MIN_LENGTH) return PASSWORD_POLICY_MESSAGE;
+  if (!/[A-Z]/.test(password)) return PASSWORD_POLICY_MESSAGE;
+  if (!/[a-z]/.test(password)) return PASSWORD_POLICY_MESSAGE;
+  if (!/[0-9]/.test(password)) return PASSWORD_POLICY_MESSAGE;
+  if (!/[^A-Za-z0-9]/.test(password)) return PASSWORD_POLICY_MESSAGE;
+
+  return null;
+};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -2,6 +2,7 @@ export interface AppUser {
   id: string;
   email?: string;
   created_at?: string;
+  auth_provider?: 'password' | 'google' | string;
   user_metadata?: {
     given_name?: string;
     family_name?: string;


### PR DESCRIPTION
## Purpose

Closes #124 by adding Cognito self-service signup and account recovery on top of the AWS backend foundation from PR #126.

## Changes

- Enables Cognito self-signup and email/password auth flows in the CDK auth stack.
- Adds AWS-mode email/password login, signup, email verification, forgot password, reset password, profile email verification, and password update flows.
- Reuses the existing auth tab UI for AWS while keeping Supabase as the default backend/auth path.
- Keeps AWS behavior gated behind `VITE_BACKEND=aws` and does not add realtime sync or change game persistence semantics.
- Adds focused tests for Cognito/API mock signup, reset, login, and error states.

## Validation

- `npm run lint`
- `npm run build`
- `VITE_BACKEND=aws VITE_AUTH_MOCK=1 VITE_SUPABASE_URL= VITE_SUPABASE_KEY= npm run build`
- `npm run test`
- `cd infra && npm run build`
- `cd infra && npx cdk synth -c googleClientId=dummy-google-client-id`

## Notes

Plain `npm run synth` requires real CDK context for `googleClientId`; the placeholder context above was used only to validate synthesis shape.