### PR TITLE
Replay fouls in game history

### DIFF
--- a/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
+++ b/src/components/GameHistory/hooks/__tests__/useGameHistory.test.ts
@@ -91,6 +91,30 @@ describe('useGameHistory', () => {
     expect(result.current.games).toEqual([]);
   });
 
+  test('removes the local copy after a successful cloud delete', async () => {
+    const game = createMockGameData({ id: 'synced-game-to-delete' });
+    const backend = {
+      listGames: vi.fn().mockResolvedValue([game]),
+      deleteGame: vi.fn().mockResolvedValue(undefined),
+    };
+    const user = { id: 'user-1' };
+    localStorage.setItem(`runcount_game_${game.id}`, JSON.stringify(game));
+
+    const { result } = renderHook(() =>
+      useGameHistory({ backend: backend as never, user: user as never }),
+    );
+
+    await waitFor(() => expect(result.current.games).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.deleteGame(game.id);
+    });
+
+    expect(backend.deleteGame).toHaveBeenCalledWith(game.id);
+    expect(localStorage.getItem(`runcount_game_${game.id}`)).toBeNull();
+    expect(result.current.games).toEqual([]);
+  });
+
   test('keeps the history view intact when a delete fails', async () => {
     const game = createMockGameData({ id: 'game-to-delete' });
     const backend = {

--- a/src/components/GameHistory/hooks/useGameHistory.ts
+++ b/src/components/GameHistory/hooks/useGameHistory.ts
@@ -90,9 +90,8 @@ export const useGameHistory = ({ backend, user }: UseGameHistoryProps) => {
     try {
       if (user) {
         await backend.deleteGame(gameId);
-      } else {
-        localStorage.removeItem(`${LOCAL_GAME_PREFIX}${gameId}`);
       }
+      localStorage.removeItem(`${LOCAL_GAME_PREFIX}${gameId}`);
 
       // Update local state
       setGames(games.filter((g) => g.id !== gameId));

--- a/src/components/GameScoring/hooks/__tests__/useGameState.test.ts
+++ b/src/components/GameScoring/hooks/__tests__/useGameState.test.ts
@@ -87,6 +87,64 @@ describe('useGameState', () => {
     expect(setGameId).not.toHaveBeenCalled(); // Should not generate new ID for existing game
   });
 
+  test('restores active player from saved breaking player before any actions', () => {
+    const now = new Date();
+    const saved: GameData = {
+      id: 'game-1',
+      date: now.toISOString(),
+      players: makePlayers(['Alice', 'Bob'], [75, 60]) as Player[],
+      winner_id: null,
+      completed: false,
+      actions: [],
+      breakingPlayerId: 1,
+      startTime: now.toISOString(),
+    };
+
+    const { result } = renderHook(() =>
+      useGameState({
+        players: ['Alice', 'Bob'],
+        playerTargetScores: { Alice: 75, Bob: 60 },
+        gameId: 'game-1',
+        setGameId: vi.fn(),
+        breakingPlayerId: 0,
+        getGameState: () => saved,
+        persistGame: vi.fn(),
+      }),
+    );
+
+    expect(result.current.activePlayerIndex).toBe(1);
+  });
+
+  test('derives active player from saved innings when breaking player is missing', () => {
+    const now = new Date();
+    const saved: GameData = {
+      id: 'game-1',
+      date: now.toISOString(),
+      players: makePlayers(['Alice', 'Bob'], [75, 60]).map((player, index) => ({
+        ...player,
+        innings: index === 1 ? 1 : 0,
+      })) as Player[],
+      winner_id: null,
+      completed: false,
+      actions: [],
+      startTime: now.toISOString(),
+    };
+
+    const { result } = renderHook(() =>
+      useGameState({
+        players: ['Alice', 'Bob'],
+        playerTargetScores: { Alice: 75, Bob: 60 },
+        gameId: 'game-1',
+        setGameId: vi.fn(),
+        breakingPlayerId: 0,
+        getGameState: () => saved,
+        persistGame: vi.fn(),
+      }),
+    );
+
+    expect(result.current.activePlayerIndex).toBe(1);
+  });
+
   test('restores game state with actions and calculates current state correctly', () => {
     const now = new Date();
     const actions = [

--- a/src/components/GameScoring/hooks/useGameHistory.ts
+++ b/src/components/GameScoring/hooks/useGameHistory.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { type Player, type GameAction } from '../../../types/game';
+import { replayActions } from '../utils/replayActions';
 
 interface UseGameScoringHistoryProps {
   players: string[];
@@ -46,141 +47,24 @@ export const useGameScoringHistory = ({
   const handleUndoLastAction = () => {
     if (actions.length === 0) return;
 
-    // Start with initial state
-    const initialPlayerData: Player[] = players.map((name, index) => ({
-      id: index,
-      name,
-      score: 0,
-      innings: index === breakingPlayerId ? 1 : 0,
-      highRun: 0,
-      fouls: 0,
-      consecutiveFouls: 0,
-      safeties: 0,
-      missedShots: 0,
-      targetScore: playerTargetScores[name] || 100,
-    }));
-
     // Remove the last action
     const previousActions = [...actions.slice(0, -1)];
 
-    // Reset to the initial state
-    const updatedPlayerData = [...initialPlayerData];
-    let currentInningCount = 1;
-    let currentActivePlayer = breakingPlayerId;
-    let runningBOT = 15;
-    let runningScore = 0;
-
-    // Replay all actions except the last one
-    for (let i = 0; i < previousActions.length; i++) {
-      const action = previousActions[i];
-      const playerIdx = updatedPlayerData.findIndex((p) => p.id === action.playerId);
-
-      if (playerIdx === -1) continue;
-
-      // Track who should be the active player
-      currentActivePlayer = playerIdx;
-
-      // Handle action based on type
-      switch (action.type) {
-        case 'score':
-          updatedPlayerData[playerIdx].score += action.value;
-          runningScore += action.value;
-          if (runningScore > updatedPlayerData[playerIdx].highRun) {
-            updatedPlayerData[playerIdx].highRun = runningScore;
-          }
-          if (action.ballsOnTable !== undefined) {
-            runningBOT = action.ballsOnTable;
-          }
-          break;
-
-        case 'foul': {
-          if (action.ballsOnTable !== undefined) {
-            const ballsPocketed = Math.max(0, runningBOT - action.ballsOnTable);
-            updatedPlayerData[playerIdx].score += ballsPocketed;
-            runningScore += ballsPocketed;
-            if (runningScore > updatedPlayerData[playerIdx].highRun) {
-              updatedPlayerData[playerIdx].highRun = runningScore;
-            }
-            updatedPlayerData[playerIdx].score -= 1;
-            runningBOT = action.ballsOnTable;
-          }
-
-          updatedPlayerData[playerIdx].fouls += 1;
-          updatedPlayerData[playerIdx].consecutiveFouls += 1;
-
-          const isThreeConsecutiveFouls =
-            updatedPlayerData[playerIdx].consecutiveFouls === 3;
-
-          if (isThreeConsecutiveFouls) {
-            updatedPlayerData[playerIdx].score -= 15;
-            updatedPlayerData[playerIdx].consecutiveFouls = 0;
-            runningBOT = 15;
-          }
-
-          if (!isThreeConsecutiveFouls) {
-            currentActivePlayer = (playerIdx + 1) % players.length;
-            if (currentActivePlayer === 0) {
-              currentInningCount++;
-            }
-            updatedPlayerData[currentActivePlayer].innings += 1;
-          }
-
-          runningScore = 0;
-          break;
-        }
-
-        case 'safety':
-        case 'miss':
-          if (action.ballsOnTable !== undefined) {
-            const ballsPocketed = Math.max(0, runningBOT - action.ballsOnTable);
-            updatedPlayerData[playerIdx].score += ballsPocketed;
-            runningScore += ballsPocketed;
-            if (runningScore > updatedPlayerData[playerIdx].highRun) {
-              updatedPlayerData[playerIdx].highRun = runningScore;
-            }
-            runningBOT = action.ballsOnTable;
-          }
-
-          if (action.type === 'safety') {
-            updatedPlayerData[playerIdx].safeties += 1;
-            updatedPlayerData[playerIdx].consecutiveFouls = 0;
-          } else {
-            updatedPlayerData[playerIdx].missedShots += 1;
-            updatedPlayerData[playerIdx].consecutiveFouls = 0;
-          }
-
-          currentActivePlayer = (playerIdx + 1) % players.length;
-          if (currentActivePlayer === 0) {
-            currentInningCount++;
-          }
-          updatedPlayerData[currentActivePlayer].innings += 1;
-
-          runningScore = 0;
-          break;
-      }
-    }
+    const replayedState = replayActions({
+      players,
+      playerTargetScores,
+      breakingPlayerId,
+      actions: previousActions,
+    });
 
     // Update all state values
-    setPlayerData(updatedPlayerData);
-    setActivePlayerIndex(currentActivePlayer);
-    setCurrentInning(currentInningCount);
-    setBallsOnTable(runningBOT);
-    setCurrentRun(runningScore);
+    setPlayerData(replayedState.playerData);
+    setActivePlayerIndex(replayedState.activePlayerIndex);
+    setCurrentInning(replayedState.currentInning);
+    setBallsOnTable(replayedState.ballsOnTable);
+    setCurrentRun(replayedState.currentRun);
     setActions(previousActions);
-
-    // If we're back to the initial state (no actions), make sure we reset to the breaking player
-    if (previousActions.length === 0) {
-      setActivePlayerIndex(breakingPlayerId);
-    }
-
-    // Check if the last action was a three-foul that requires re-break
-    const finalAction =
-      previousActions.length > 0 ? previousActions[previousActions.length - 1] : null;
-    if (finalAction && finalAction.type === 'foul' && finalAction.reBreak) {
-      setPlayerNeedsReBreak(finalAction.playerId);
-    } else {
-      setPlayerNeedsReBreak(null);
-    }
+    setPlayerNeedsReBreak(replayedState.playerNeedsReBreak);
 
     // If no more actions, disable undo
     if (previousActions.length === 0) {
@@ -188,7 +72,7 @@ export const useGameScoringHistory = ({
     }
 
     // Update game in database
-    persistGame(gameId, updatedPlayerData, previousActions, false, null);
+    persistGame(gameId, replayedState.playerData, previousActions, false, null);
   };
 
   return {

--- a/src/components/GameScoring/hooks/useGameState.ts
+++ b/src/components/GameScoring/hooks/useGameState.ts
@@ -22,6 +22,20 @@ interface UseGameStateProps {
   ) => void;
 }
 
+const getRestoredBreakingPlayerIndex = (
+  savedGameState: GameData,
+  fallbackBreakingPlayerId: number,
+) => {
+  if (typeof savedGameState.breakingPlayerId === 'number') {
+    return savedGameState.breakingPlayerId;
+  }
+
+  const inningPlayerIndex = savedGameState.players.findIndex(
+    (player) => player.innings > 0,
+  );
+  return inningPlayerIndex === -1 ? fallbackBreakingPlayerId : inningPlayerIndex;
+};
+
 export const useGameState = ({
   players,
   playerTargetScores,
@@ -31,7 +45,13 @@ export const useGameState = ({
   getGameState,
   persistGame,
 }: UseGameStateProps) => {
-  const [activePlayerIndex, setActivePlayerIndexState] = useState(() => breakingPlayerId);
+  const [activePlayerIndex, setActivePlayerIndexState] = useState(() => {
+    const saved = getGameState();
+    if (saved && saved.id === gameId) {
+      return getRestoredBreakingPlayerIndex(saved, breakingPlayerId);
+    }
+    return breakingPlayerId;
+  });
 
   const setActivePlayerIndex = (index: number) => {
     setActivePlayerIndexState(index);
@@ -88,7 +108,11 @@ export const useGameState = ({
       setActions(savedGameState.actions);
 
       // Calculate current state based on actions
-      let activePlayer = 0;
+      const restoredBreakingPlayer = getRestoredBreakingPlayerIndex(
+        savedGameState,
+        breakingPlayerId,
+      );
+      let activePlayer = restoredBreakingPlayer;
       let currentInningValue = 1;
       let currentRunValue = 0;
       let currentBOT = 15;

--- a/src/components/GameScoring/index.tsx
+++ b/src/components/GameScoring/index.tsx
@@ -133,6 +133,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
             date: new Date().toISOString(),
             players: gameState.players,
             actions: gameState.actions,
+            breakingPlayerId: gameState.breakingPlayerId ?? currentBreakingPlayerId,
             completed: gameState.completed,
             winner_id: gameState.winner_id,
             deleted: false,
@@ -148,7 +149,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
 
       saveCurrentGameToCloud();
     }
-  }, [user, gameId, backend, getGameState, addError]);
+  }, [user, gameId, backend, getGameState, addError, currentBreakingPlayerId]);
 
   // Game state management
   const {
@@ -180,7 +181,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
     playerTargetScores,
     gameId,
     setGameId,
-    breakingPlayerId,
+    breakingPlayerId: currentBreakingPlayerId,
     getGameState,
     persistGame: async (
       gameId,
@@ -211,6 +212,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
           gameId,
           players,
           actions,
+          breakingPlayerId: currentBreakingPlayerId,
           completed,
           winner_id,
         });
@@ -262,6 +264,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
             gameId,
             players,
             actions,
+            breakingPlayerId: currentBreakingPlayerId,
             completed,
             winner_id,
           });
@@ -321,6 +324,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
           gameId,
           players,
           actions,
+          breakingPlayerId: currentBreakingPlayerId,
           completed,
           winner_id,
         });
@@ -410,6 +414,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
       date: new Date().toISOString(),
       players: updatedPlayerData,
       actions,
+      breakingPlayerId: currentBreakingPlayerId,
       completed: false,
       winner_id: null,
       turnStartTime: newTurnStartTime,
@@ -427,6 +432,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
     gameId,
     saveGameState,
     _setTurnStartTime,
+    currentBreakingPlayerId,
   ]);
 
   // Memoize require re-break handler
@@ -456,6 +462,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
       date: new Date().toISOString(),
       players: updatedPlayerData,
       actions,
+      breakingPlayerId: currentBreakingPlayerId,
       completed: false,
       winner_id: null,
     });
@@ -470,6 +477,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
     actions,
     gameId,
     saveGameState,
+    currentBreakingPlayerId,
   ]);
 
   const handleEndGame = () => {
@@ -491,6 +499,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
         gameId,
         players: playerData,
         actions,
+        breakingPlayerId: currentBreakingPlayerId,
         completed: true,
         winner_id: gameWinner?.id ?? null,
       });
@@ -632,6 +641,7 @@ const GameScoring: React.FC<GameScoringProps> = ({
         date: new Date().toISOString(),
         players: updatedPlayerData,
         actions,
+        breakingPlayerId: newBreakingPlayerId,
         completed: false,
         winner_id: null,
         turnStartTime: newTurnStartTime,

--- a/src/components/GameScoring/utils/replayActions.test.ts
+++ b/src/components/GameScoring/utils/replayActions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+
+import { replayActions } from './replayActions';
+
+import type { GameAction } from '../../../types/game';
+
+const timestamp = new Date('2026-07-02T12:00:00.000Z');
+
+const replay = (actions: GameAction[]) =>
+  replayActions({
+    players: ['Alice', 'Bob'],
+    playerTargetScores: { Alice: 150, Bob: 150 },
+    breakingPlayerId: 0,
+    actions,
+  });
+
+const foul = (overrides: Partial<GameAction> = {}): GameAction => ({
+  type: 'foul',
+  playerId: 0,
+  value: -1,
+  timestamp,
+  ballsOnTable: 15,
+  ...overrides,
+});
+
+const miss = (playerId: number): GameAction => ({
+  type: 'miss',
+  playerId,
+  value: 0,
+  timestamp,
+  ballsOnTable: 15,
+});
+
+describe('replayActions', () => {
+  test('replays a two-point opening break foul without advancing consecutive fouls', () => {
+    const state = replay([
+      foul({
+        value: -2,
+        ballsOnTable: 14,
+        isBreakFoul: true,
+        reBreak: false,
+      }),
+    ]);
+
+    expect(state.playerData[0].score).toBe(-1);
+    expect(state.playerData[0].fouls).toBe(1);
+    expect(state.playerData[0].consecutiveFouls).toBe(0);
+    expect(state.activePlayerIndex).toBe(0);
+    expect(state.currentInning).toBe(1);
+  });
+
+  test('replays a one-point break scratch as a consecutive standard foul', () => {
+    const state = replay([
+      foul({
+        value: -1,
+        isBreakFoul: true,
+        reBreak: false,
+      }),
+    ]);
+
+    expect(state.playerData[0].score).toBe(-1);
+    expect(state.playerData[0].fouls).toBe(1);
+    expect(state.playerData[0].consecutiveFouls).toBe(1);
+    expect(state.activePlayerIndex).toBe(0);
+  });
+
+  test('uses recorded reBreak metadata to apply the automatic three-foul penalty', () => {
+    const state = replay([foul(), miss(1), foul(), miss(1), foul({ reBreak: true })]);
+
+    expect(state.playerData[0].score).toBe(-18);
+    expect(state.playerData[0].fouls).toBe(3);
+    expect(state.playerData[0].consecutiveFouls).toBe(0);
+    expect(state.ballsOnTable).toBe(15);
+    expect(state.activePlayerIndex).toBe(0);
+    expect(state.playerNeedsReBreak).toBe(0);
+  });
+
+  test('honors manual three-foul reBreak actions even below two prior fouls', () => {
+    const state = replay([foul({ reBreak: true })]);
+
+    expect(state.playerData[0].score).toBe(-16);
+    expect(state.playerData[0].fouls).toBe(1);
+    expect(state.playerData[0].consecutiveFouls).toBe(0);
+    expect(state.activePlayerIndex).toBe(0);
+    expect(state.playerNeedsReBreak).toBe(0);
+  });
+
+  test('does not infer a three-foul penalty for a recorded manual regular override', () => {
+    const state = replay([foul(), miss(1), foul(), miss(1), foul({ reBreak: false })]);
+
+    expect(state.playerData[0].score).toBe(-3);
+    expect(state.playerData[0].fouls).toBe(3);
+    expect(state.playerData[0].consecutiveFouls).toBe(1);
+    expect(state.playerNeedsReBreak).toBeNull();
+    expect(state.activePlayerIndex).toBe(1);
+  });
+
+  test('advances turns only for non-break and non-rebreak terminal actions', () => {
+    expect(replay([foul({ isBreakFoul: true })]).activePlayerIndex).toBe(0);
+    expect(replay([foul({ reBreak: true })]).activePlayerIndex).toBe(0);
+
+    const state = replay([foul(), foul({ playerId: 1 })]);
+
+    expect(state.activePlayerIndex).toBe(0);
+    expect(state.currentInning).toBe(2);
+    expect(state.playerData[0].innings).toBe(2);
+    expect(state.playerData[1].innings).toBe(1);
+  });
+});

--- a/src/components/GameScoring/utils/replayActions.ts
+++ b/src/components/GameScoring/utils/replayActions.ts
@@ -1,0 +1,163 @@
+import { type GameAction, type Player } from '../../../types/game';
+
+const THREE_FOUL_PENALTY = 15;
+
+interface ReplayActionsParams {
+  players: string[];
+  playerTargetScores: Record<string, number>;
+  breakingPlayerId: number;
+  actions: GameAction[];
+}
+
+interface ReplayedGameState {
+  playerData: Player[];
+  activePlayerIndex: number;
+  currentInning: number;
+  ballsOnTable: number;
+  currentRun: number;
+  playerNeedsReBreak: number | null;
+}
+
+const resolveNextTableState = (ballsOnTable: number) =>
+  ballsOnTable === 0 ? 15 : ballsOnTable;
+
+const createInitialPlayerData = (
+  players: string[],
+  playerTargetScores: Record<string, number>,
+  breakingPlayerId: number,
+): Player[] =>
+  players.map((name, index) => ({
+    id: index,
+    name,
+    score: 0,
+    innings: index === breakingPlayerId ? 1 : 0,
+    highRun: 0,
+    fouls: 0,
+    consecutiveFouls: 0,
+    safeties: 0,
+    missedShots: 0,
+    targetScore: playerTargetScores[name] || 100,
+  }));
+
+export const replayActions = ({
+  players,
+  playerTargetScores,
+  breakingPlayerId,
+  actions,
+}: ReplayActionsParams): ReplayedGameState => {
+  const playerData = createInitialPlayerData(
+    players,
+    playerTargetScores,
+    breakingPlayerId,
+  );
+  let currentInning = 1;
+  let activePlayerIndex = breakingPlayerId;
+  let ballsOnTable = 15;
+  let currentRun = 0;
+  let playerNeedsReBreak: number | null = null;
+
+  const updateHighRun = (playerIndex: number) => {
+    if (currentRun > playerData[playerIndex].highRun) {
+      playerData[playerIndex].highRun = currentRun;
+    }
+  };
+
+  const applyPocketedBalls = (action: GameAction, playerIndex: number) => {
+    if (action.ballsOnTable === undefined) return;
+
+    const ballsPocketed = Math.max(0, ballsOnTable - action.ballsOnTable);
+    playerData[playerIndex].score += ballsPocketed;
+    currentRun += ballsPocketed;
+    updateHighRun(playerIndex);
+    ballsOnTable = resolveNextTableState(action.ballsOnTable);
+  };
+
+  const advanceTurn = (playerIndex: number) => {
+    activePlayerIndex = (playerIndex + 1) % playerData.length;
+    if (activePlayerIndex === 0) {
+      currentInning += 1;
+    }
+    playerData[activePlayerIndex].innings += 1;
+  };
+
+  for (const action of actions) {
+    const playerIndex = playerData.findIndex((player) => player.id === action.playerId);
+    if (playerIndex === -1) continue;
+
+    activePlayerIndex = playerIndex;
+
+    switch (action.type) {
+      case 'score':
+        if (playerNeedsReBreak === action.playerId) {
+          playerNeedsReBreak = null;
+        }
+        playerData[playerIndex].score += action.value;
+        playerData[playerIndex].consecutiveFouls = 0;
+        currentRun += action.value;
+        updateHighRun(playerIndex);
+        if (action.ballsOnTable !== undefined) {
+          ballsOnTable = resolveNextTableState(action.ballsOnTable);
+        }
+        break;
+
+      case 'foul': {
+        applyPocketedBalls(action, playerIndex);
+
+        playerData[playerIndex].fouls += 1;
+
+        const isTwoPointBreakingFoul = action.isBreakFoul === true && action.value === -2;
+
+        if (!isTwoPointBreakingFoul) {
+          playerData[playerIndex].consecutiveFouls += 1;
+        }
+
+        playerData[playerIndex].score += action.value;
+
+        if (action.reBreak) {
+          playerData[playerIndex].score -= THREE_FOUL_PENALTY;
+          playerData[playerIndex].consecutiveFouls = 0;
+          ballsOnTable = 15;
+          playerNeedsReBreak = action.playerId;
+        } else {
+          if (!isTwoPointBreakingFoul && playerData[playerIndex].consecutiveFouls >= 3) {
+            playerData[playerIndex].consecutiveFouls = 1;
+          }
+
+          if (!action.isBreakFoul) {
+            advanceTurn(playerIndex);
+          }
+        }
+
+        currentRun = 0;
+        break;
+      }
+
+      case 'safety':
+      case 'miss':
+        if (playerNeedsReBreak === action.playerId) {
+          playerNeedsReBreak = null;
+        }
+        applyPocketedBalls(action, playerIndex);
+
+        if (action.type === 'safety') {
+          playerData[playerIndex].safeties += 1;
+        } else {
+          playerData[playerIndex].missedShots += 1;
+        }
+
+        playerData[playerIndex].consecutiveFouls = 0;
+        advanceTurn(playerIndex);
+        currentRun = 0;
+        break;
+    }
+  }
+
+  return {
+    playerData,
+    activePlayerIndex,
+    currentInning,
+    ballsOnTable,
+    currentRun,
+    playerNeedsReBreak,
+  };
+};

--- a/src/hooks/__tests__/useGameState.test.ts
+++ b/src/hooks/__tests__/useGameState.test.ts
@@ -36,6 +36,7 @@ describe('useGameState', () => {
       createMockGameData({
         id: 'saved-game',
         completed: false,
+        breakingPlayerId: 1,
         players: [
           createMockPlayer({ id: 0, name: 'Alice', targetScore: 75 }),
           createMockPlayer({ id: 1, name: 'Bob', targetScore: 60 }),
@@ -51,8 +52,25 @@ describe('useGameState', () => {
     expect(result.current.players).toEqual(['Alice', 'Bob']);
     expect(result.current.playerTargetScores).toEqual({ Alice: 75, Bob: 60 });
     expect(result.current.currentGameId).toBe('saved-game');
+    expect(result.current.breakingPlayerId).toBe(1);
     expect(result.current.matchStartTime?.toISOString()).toBe('2026-01-01T00:00:00.000Z');
     expect(result.current.turnStartTime?.toISOString()).toBe('2026-01-01T00:01:00.000Z');
+  });
+
+  test('derives saved breaking player from innings when missing from legacy data', () => {
+    getGameState.mockReturnValue(
+      createMockGameData({
+        completed: false,
+        players: [
+          createMockPlayer({ id: 0, name: 'Alice', innings: 0 }),
+          createMockPlayer({ id: 1, name: 'Bob', innings: 1 }),
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useGameState());
+
+    expect(result.current.breakingPlayerId).toBe(1);
   });
 
   test('clears completed active saved games and stays on setup', () => {

--- a/src/hooks/useGameSave.test.ts
+++ b/src/hooks/useGameSave.test.ts
@@ -34,15 +34,19 @@ describe('persistGameHelper', () => {
       gameId,
       players,
       actions,
+      breakingPlayerId: 1,
       completed: false,
       winner_id: null,
     });
 
     expect(saveGameState).toHaveBeenCalledTimes(1);
+    expect(saveGameState).toHaveBeenCalledWith(
+      expect.objectContaining({ breakingPlayerId: 1 }),
+    );
     expect(clearGameState).not.toHaveBeenCalled();
     expect(window.localStorage.setItem).toHaveBeenCalledWith(
       `runcount_game_${gameId}`,
-      expect.stringContaining('"id":"game-123"'),
+      expect.stringContaining('"breakingPlayerId":1'),
     );
     expect(saveGameSpy).not.toHaveBeenCalled();
   });
@@ -60,6 +64,7 @@ describe('persistGameHelper', () => {
       gameId,
       players,
       actions,
+      breakingPlayerId: 1,
       completed: false,
       winner_id: 0,
     });
@@ -71,6 +76,7 @@ describe('persistGameHelper', () => {
       id: gameId,
       players,
       actions,
+      breakingPlayerId: 1,
       completed: false,
       winner_id: 0,
       deleted: false,

--- a/src/hooks/useGameSave.ts
+++ b/src/hooks/useGameSave.ts
@@ -24,6 +24,7 @@ export const persistGameHelper = async (options: {
   matchStartTime?: string;
   matchEndTime?: string;
   turnStartTime?: string;
+  breakingPlayerId?: number;
   gameId: string;
   players: Player[];
   actions: GameAction[];
@@ -38,6 +39,7 @@ export const persistGameHelper = async (options: {
     matchStartTime,
     matchEndTime,
     turnStartTime,
+    breakingPlayerId,
     gameId,
     players,
     actions,
@@ -53,6 +55,7 @@ export const persistGameHelper = async (options: {
       date: new Date().toISOString(),
       players,
       actions,
+      breakingPlayerId,
       completed,
       winner_id: winnerId,
       startTime: matchStartTime,
@@ -66,6 +69,7 @@ export const persistGameHelper = async (options: {
     date: new Date().toISOString(),
     players,
     actions,
+    breakingPlayerId,
     completed,
     winner_id: winnerId,
     startTime: matchStartTime,
@@ -92,6 +96,7 @@ export const persistGameHelper = async (options: {
       date: now.toISOString(),
       players,
       actions,
+      breakingPlayerId,
       completed,
       winner_id: winnerId,
       deleted: false,

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -2,6 +2,8 @@ import { useState, useCallback, useEffect } from 'react';
 
 import { useGamePersist } from '../context/GamePersistContext';
 
+import type { GameData } from '../types/game';
+
 // Game states
 export type GameState =
   | 'setup'
@@ -10,6 +12,14 @@ export type GameState =
   | 'history'
   | 'trends'
   | 'profile';
+
+const getRestoredBreakingPlayerId = (saved: GameData | null) => {
+  if (!saved || saved.completed) return 0;
+  if (typeof saved.breakingPlayerId === 'number') return saved.breakingPlayerId;
+
+  const breakingPlayerIndex = saved.players.findIndex((player) => player.innings > 0);
+  return breakingPlayerIndex === -1 ? 0 : breakingPlayerIndex;
+};
 
 /**
  * Custom hook for managing game state and related data
@@ -50,7 +60,9 @@ export const useGameState = () => {
     return saved && !saved.completed ? saved.id : null;
   });
 
-  const [breakingPlayerId, setBreakingPlayerId] = useState<number>(0);
+  const [breakingPlayerId, setBreakingPlayerId] = useState<number>(() =>
+    getRestoredBreakingPlayerId(getGameState()),
+  );
 
   // Timer state for header display during scoring
   const [matchStartTime, setMatchStartTime] = useState<Date | null>(() => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -38,6 +38,7 @@ export interface GameData {
   winner_id: number | null;
   completed: boolean;
   actions: GameAction[];
+  breakingPlayerId?: number; // Index of the player who is breaking
   owner_id?: string; // UUID string from auth.users.id
   deleted?: boolean; // Flag for soft deletion
   startTime?: Date | string; // When the match timer started

--- a/src/utils/gameValidation.test.ts
+++ b/src/utils/gameValidation.test.ts
@@ -75,6 +75,11 @@ describe('isValidGameData', () => {
     expect(isValidGameData({ ...validGame(), winner_id: 'uuid-123' })).toBe(true);
   });
 
+  it('accepts numeric breakingPlayerId and rejects wrong types', () => {
+    expect(isValidGameData({ ...validGame(), breakingPlayerId: 1 })).toBe(true);
+    expect(isValidGameData({ ...validGame(), breakingPlayerId: '1' })).toBe(false);
+  });
+
   it('rejects empty id, empty players, bad actions', () => {
     expect(isValidGameData({ ...validGame(), id: '' })).toBe(false);
     expect(isValidGameData({ ...validGame(), players: [] })).toBe(false);

--- a/src/utils/gameValidation.ts
+++ b/src/utils/gameValidation.ts
@@ -66,6 +66,12 @@ export const isValidGameData = (value: unknown): value is GameData => {
     return false;
   }
   if (typeof value.completed !== 'boolean') return false;
+  if (
+    value.breakingPlayerId !== undefined &&
+    typeof value.breakingPlayerId !== 'number'
+  ) {
+    return false;
+  }
   return true;
 };
 


### PR DESCRIPTION
## Summary
- Adds `replayActions` module to support replaying foul events through game history
- Updates GameScoring/GameHistory hooks and validation to support replay

## Test plan
- [ ] Manual smoke test of foul replay in GameScoring UI
- [ ] Unit tests included (`replayActions.test.ts`, updated hook tests)