### PR TITLE
Remove Test badge from RunCount header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,12 +23,7 @@ export const Header: FC<HeaderProps> = ({
 }) => {
   return (
     <header className="rc-topbar">
-      <h1 className="rc-brand flex items-center gap-2">
-        RunCount
-        <span className="rounded-full bg-white/20 px-2 py-0.5 text-[10px] font-semibold tracking-wide">
-          Test ✓
-        </span>
-      </h1>
+      <h1 className="rc-brand">RunCount</h1>
       <div className="rc-topbar-right">
         <button
           onClick={toggleDarkMode}


### PR DESCRIPTION
Removes the temporary "Test ✓" pill that was added to the header brand in 4e3a989 to verify the deploy pipeline. That commit was pushed directly to main and auto-deployed, so the badge is currently visible in production — merging this restores the plain `RunCount` header.

## Changes
- `src/components/Header.tsx`: revert the `<h1 class="rc-brand">` to plain "RunCount", dropping the badge span and its flex layout classes (net −5 lines).

## Validation
- Production build (`npm run build`) succeeds.
- Confirmed the built JS bundles no longer contain the "Test ✓" string.

Merging to main will trigger the deploy workflow and remove the badge from https://runcount.rbios.net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByK15SHWVcw8HSt6acGpzP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByK15SHWVcw8HSt6acGpzP)_