### PR TITLE
Fix consecutive-foul reset after intervening legal shots

### DIFF
--- a/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
+++ b/src/components/GameScoring/__tests__/GameScoring.consecutiveFoul.integration.test.tsx
@@ -155,4 +155,41 @@ describe('GameScoring consecutive foul flow', () => {
       expect(screen.getByText('Re-Break')).toBeInTheDocument();
     });
   }, 15000);
+
+  test('skips the three-foul prompt when the inning includes a legal scoring shot', async () => {
+    render(
+      <GameScoring
+        players={['Alice', 'Bob']}
+        playerTargetScores={{ Alice: 100, Bob: 100 }}
+        gameId="saved-game-1"
+        setGameId={() => {}}
+        finishGame={() => {}}
+        backend={backend}
+        user={null}
+        breakingPlayerId={0}
+        shotClockSeconds={15}
+        matchStartTime={null}
+        matchEndTime={null}
+        setMatchStartTime={() => {}}
+        setMatchEndTime={() => {}}
+        turnStartTime={null}
+        setTurnStartTime={() => {}}
+        ballsOnTable={15}
+        setBallsOnTable={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('2 Fouls')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /^Foul$/i }));
+    await userEvent.click(await screen.findByRole('button', { name: '13' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Alice was on two fouls/i)).not.toBeInTheDocument();
+      expect(screen.queryByText('2 Fouls')).not.toBeInTheDocument();
+      expect(screen.getByTestId('player-score-0')).toHaveTextContent('-1');
+    });
+  }, 15000);
 });

--- a/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
+++ b/src/components/GameScoring/hooks/__tests__/useGameActions.test.ts
@@ -250,11 +250,11 @@ describe('useGameActions', () => {
     players[0].consecutiveFouls = 2;
 
     act(() => {
-      result.current.handleAddFoul(14);
+      result.current.handleAddFoul(15);
     });
 
-    // Three consecutive standard fouls: balls pocketed (1) - standard foul (-1) - three foul penalty (-15) = -15
-    expect(players[0].score).toBe(-15);
+    // Three consecutive standard fouls: standard foul (-1) + three-foul penalty (-15)
+    expect(players[0].score).toBe(-16);
     expect(players[0].consecutiveFouls).toBe(0); // reset after penalty
     expect(mocks.setShowAlertModal).toHaveBeenCalledWith(true);
     expect(mocks.setAlertMessage).toHaveBeenCalledWith(
@@ -461,7 +461,7 @@ describe('useGameActions', () => {
     players[0].consecutiveFouls = 1; // Already has one foul
 
     act(() => {
-      result.current.handleAddFoul(14);
+      result.current.handleAddFoul(15);
     });
 
     expect(players[0].consecutiveFouls).toBe(2);
@@ -469,6 +469,47 @@ describe('useGameActions', () => {
       expect.stringContaining('two consecutive fouls'),
     );
     expect(mocks.setShowAlertModal).toHaveBeenCalledWith(true);
+  });
+
+  test('starts a new foul sequence when legal balls were made before the foul', () => {
+    const testHarness = setup({
+      ballsOnTable: 15,
+      actions: [{ type: 'score', playerId: 1, value: 1, timestamp: new Date() }],
+    });
+    const { result, players, mocks } = testHarness;
+    players[0].consecutiveFouls = 1;
+
+    act(() => {
+      result.current.handleAddFoul(13);
+    });
+
+    expect(players[0].score).toBe(1);
+    expect(players[0].consecutiveFouls).toBe(1);
+    expect(testHarness.actions.at(-1)).toMatchObject({ type: 'foul', reBreak: false });
+    expect(mocks.setAlertMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('two consecutive fouls'),
+    );
+  });
+
+  test('does not apply a three-foul penalty after an intervening legal shot', () => {
+    const testHarness = setup({
+      ballsOnTable: 15,
+      actions: [{ type: 'score', playerId: 1, value: 1, timestamp: new Date() }],
+    });
+    const { result, players, mocks } = testHarness;
+    players[0].consecutiveFouls = 2;
+
+    act(() => {
+      result.current.handleAddFoul(13);
+    });
+
+    expect(players[0].score).toBe(1);
+    expect(players[0].consecutiveFouls).toBe(1);
+    expect(testHarness.actions.at(-1)).toMatchObject({ type: 'foul', reBreak: false });
+    expect(mocks.setPlayerNeedsReBreak).not.toHaveBeenCalled();
+    expect(mocks.setAlertMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('three consecutive fouls'),
+    );
   });
 
   test('handles re-break player correctly for all action types', () => {

--- a/src/components/GameScoring/hooks/useGameActions.ts
+++ b/src/components/GameScoring/hooks/useGameActions.ts
@@ -147,8 +147,16 @@ export const useGameActions = ({
     // fouls do (including a 1-point scratch on an otherwise legal break).
     const isBreakingFoul = isOpeningBreak && Math.abs(penaltyValue) === 2;
 
+    const ballsPocketed = Math.max(0, ballsOnTable - botsValue);
+    // Scored balls represent at least one intervening legal shot, which breaks
+    // the prior consecutive-foul sequence under WPA 3.13. The foul ending this
+    // inning therefore starts a new sequence instead of extending the old one.
+    const hasInterveningLegalShot = ballsPocketed > 0;
+
     const isThirdConsecutiveFoul =
-      playerData[playerIndex].consecutiveFouls === 2 && !isBreakingFoul;
+      playerData[playerIndex].consecutiveFouls === 2 &&
+      !isBreakingFoul &&
+      !hasInterveningLegalShot;
 
     const manualDecision = options?.manualConsecutiveDecision;
     const isManualThreeFoul = manualDecision === 'threeFoul';
@@ -163,7 +171,6 @@ export const useGameActions = ({
       isBreakFoul: isOpeningBreak,
     };
 
-    const ballsPocketed = Math.max(0, ballsOnTable - botsValue);
     setBallsOnTable(resolveNextTableState(botsValue));
     setActions([...actions, newAction]);
     setIsUndoEnabled(true);
@@ -187,7 +194,9 @@ export const useGameActions = ({
     // A breaking foul is still a foul (counts toward total fouls) but does not
     // advance the consecutive-foul count under WPA 4.11.
     if (!isBreakingFoul) {
-      updatedPlayerData[playerIndex].consecutiveFouls = previousConsecutiveFouls + 1;
+      updatedPlayerData[playerIndex].consecutiveFouls = hasInterveningLegalShot
+        ? 1
+        : previousConsecutiveFouls + 1;
     }
     updatedPlayerData[playerIndex].fouls += 1;
 

--- a/src/components/GameScoring/index.tsx
+++ b/src/components/GameScoring/index.tsx
@@ -578,8 +578,11 @@ const GameScoring: React.FC<GameScoringProps> = ({
       handleAddScore(0, botsValue);
       resetBotActionState();
     } else if (botAction === 'foul') {
+      const hasInterveningLegalShot = Math.max(0, ballsOnTable - botsValue) > 0;
+
       if (
         !isBreakShotContext &&
+        !hasInterveningLegalShot &&
         playerData[activePlayerIndex]?.consecutiveFouls !== undefined &&
         playerData[activePlayerIndex].consecutiveFouls >= 2
       ) {

--- a/src/components/GameScoring/utils/replayActions.test.ts
+++ b/src/components/GameScoring/utils/replayActions.test.ts
@@ -95,6 +95,15 @@ describe('replayActions', () => {
     expect(state.activePlayerIndex).toBe(1);
   });
 
+  test('restarts the foul sequence after legally pocketed balls', () => {
+    const state = replay([foul(), miss(1), foul({ ballsOnTable: 13 })]);
+
+    expect(state.playerData[0].score).toBe(0);
+    expect(state.playerData[0].fouls).toBe(2);
+    expect(state.playerData[0].consecutiveFouls).toBe(1);
+    expect(state.playerNeedsReBreak).toBeNull();
+  });
+
   test('advances turns only for non-break and non-rebreak terminal actions', () => {
     expect(replay([foul({ isBreakFoul: true })]).activePlayerIndex).toBe(0);
     expect(replay([foul({ reBreak: true })]).activePlayerIndex).toBe(0);

--- a/src/components/GameScoring/utils/replayActions.ts
+++ b/src/components/GameScoring/utils/replayActions.ts
@@ -63,13 +63,14 @@ export const replayActions = ({
   };
 
   const applyPocketedBalls = (action: GameAction, playerIndex: number) => {
-    if (action.ballsOnTable === undefined) return;
+    if (action.ballsOnTable === undefined) return 0;
 
     const ballsPocketed = Math.max(0, ballsOnTable - action.ballsOnTable);
     playerData[playerIndex].score += ballsPocketed;
     currentRun += ballsPocketed;
     updateHighRun(playerIndex);
     ballsOnTable = resolveNextTableState(action.ballsOnTable);
+    return ballsPocketed;
   };
 
   const advanceTurn = (playerIndex: number) => {
@@ -101,14 +102,15 @@ export const replayActions = ({
         break;
 
       case 'foul': {
-        applyPocketedBalls(action, playerIndex);
+        const ballsPocketed = applyPocketedBalls(action, playerIndex);
 
         playerData[playerIndex].fouls += 1;
 
         const isTwoPointBreakingFoul = action.isBreakFoul === true && action.value === -2;
 
         if (!isTwoPointBreakingFoul) {
-          playerData[playerIndex].consecutiveFouls += 1;
+          playerData[playerIndex].consecutiveFouls =
+            ballsPocketed > 0 ? 1 : playerData[playerIndex].consecutiveFouls + 1;
         }
 
         playerData[playerIndex].score += action.value;


### PR DESCRIPTION
Fixes #143. Restarts the consecutive-foul sequence when a player pockets legal balls before an inning-ending foul, suppresses the incorrect warning and three-foul prompt, and keeps action replay consistent. Validation: focused regression tests, full test suite, repository lint, and production build all pass.